### PR TITLE
Added an upper bound on the composer constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,11 @@
 
     "require": {
         "php":                      ">=5.3.2",
-        "symfony/framework-bundle": ">=2.0.0"
+        "symfony/framework-bundle": ">=2.0,<2.2-dev"
+    },
+
+    "suggest": {
+        "symfony/twig-bundle": "to use the Twig time_diff function"
     },
 
     "autoload": {


### PR DESCRIPTION
This adds an upper bound on the constraint to avoid breaking things later (tagging a release with the previous constraint requires knowing the future) and adds a suggestion on TwigBundle
