### PR TITLE
Fix chinese translation

### DIFF
--- a/Resources/translations/time.zh.xliff
+++ b/Resources/translations/time.zh.xliff
@@ -12,7 +12,7 @@
             </trans-unit>
             <trans-unit id="3">
                 <source>diff.ago.day</source>
-                <target>1 天以前|%count% 天意钱</target>
+                <target>1 天以前|%count% 天以前</target>
             </trans-unit>
             <trans-unit id="4">
                 <source>diff.ago.hour</source>
@@ -32,27 +32,27 @@
             </trans-unit>
             <trans-unit id="8">
                 <source>diff.in.second</source>
-                <target>恩 等 1 秒|恩 等 %count% 秒</target>
+                <target>1 秒后|%count% 秒后</target>
             </trans-unit>
             <trans-unit id="9">
                 <source>diff.in.hour</source>
-                <target>恩 等 1 个小时|恩 等 %count% 个小时</target>
+                <target>1 个小时后|%count% 个小时后</target>
             </trans-unit>
             <trans-unit id="10">
                 <source>diff.in.minute</source>
-                <target>恩 等 1 分钟|恩 等 %count% 分钟</target>
+                <target>1 分钟后|%count% 分钟后</target>
             </trans-unit>
             <trans-unit id="11">
                 <source>diff.in.day</source>
-                <target>恩 等 1 天|恩 等 %count% 天</target>
+                <target>1 天后|%count% 天后</target>
             </trans-unit>
             <trans-unit id="12">
                 <source>diff.in.month</source>
-                <target>恩 等 1 个月|恩 等 %count% 个月</target>
+                <target>1 个月后|%count% 个月后</target>
             </trans-unit>
             <trans-unit id="13">
                 <source>diff.in.year</source>
-                <target>恩 等 1 年|恩 等 %count% 年</target>
+                <target>1 年后|%count% 年后</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/time.zh_CN.xliff
+++ b/Resources/translations/time.zh_CN.xliff
@@ -1,0 +1,59 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>diff.ago.year</source>
+                <target>1 年以前|%count% 年以前</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>diff.ago.month</source>
+                <target>1 个月以前|%count% 个月以前</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>diff.ago.day</source>
+                <target>1 天以前|%count% 天以前</target>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>diff.ago.hour</source>
+                <target>1 个小时以前|%count% 小时以前</target>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>diff.ago.minute</source>
+                <target>1 分钟以前|%count% 分钟以前</target>
+            </trans-unit>
+            <trans-unit id="6">
+                <source>diff.ago.second</source>
+                <target>1 秒以前|%count% 秒以前</target>
+            </trans-unit>
+            <trans-unit id="7">
+                <source>diff.empty</source>
+                <target>刚才</target>
+            </trans-unit>
+            <trans-unit id="8">
+                <source>diff.in.second</source>
+                <target>1 秒后|%count% 秒后</target>
+            </trans-unit>
+            <trans-unit id="9">
+                <source>diff.in.hour</source>
+                <target>1 个小时后|%count% 个小时后</target>
+            </trans-unit>
+            <trans-unit id="10">
+                <source>diff.in.minute</source>
+                <target>1 分钟后|%count% 分钟后</target>
+            </trans-unit>
+            <trans-unit id="11">
+                <source>diff.in.day</source>
+                <target>1 天后|%count% 天后</target>
+            </trans-unit>
+            <trans-unit id="12">
+                <source>diff.in.month</source>
+                <target>1 个月后|%count% 个月后</target>
+            </trans-unit>
+            <trans-unit id="13">
+                <source>diff.in.year</source>
+                <target>1 年后|%count% 年后</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/translations/time.zh_HK.xliff
+++ b/Resources/translations/time.zh_HK.xliff
@@ -1,0 +1,59 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>diff.ago.year</source>
+                <target>1 年以前|%count% 年以前</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>diff.ago.month</source>
+                <target>1 個月以前|%count% 個月以前</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>diff.ago.day</source>
+                <target>1 天以前|%count% 天以前</target>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>diff.ago.hour</source>
+                <target>1 個小時以前|%count% 小時以前</target>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>diff.ago.minute</source>
+                <target>1 分鐘以前|%count% 分鐘以前</target>
+            </trans-unit>
+            <trans-unit id="6">
+                <source>diff.ago.second</source>
+                <target>1 秒以前|%count% 秒以前</target>
+            </trans-unit>
+            <trans-unit id="7">
+                <source>diff.empty</source>
+                <target>剛才</target>
+            </trans-unit>
+            <trans-unit id="8">
+                <source>diff.in.second</source>
+                <target>1 秒後|%count% 秒後</target>
+            </trans-unit>
+            <trans-unit id="9">
+                <source>diff.in.hour</source>
+                <target>1 個小時後|%count% 個小時後</target>
+            </trans-unit>
+            <trans-unit id="10">
+                <source>diff.in.minute</source>
+                <target>1 分鐘後|%count% 分鐘後</target>
+            </trans-unit>
+            <trans-unit id="11">
+                <source>diff.in.day</source>
+                <target>1 天後|%count% 天後</target>
+            </trans-unit>
+            <trans-unit id="12">
+                <source>diff.in.month</source>
+                <target>1 個月後|%count% 個月後</target>
+            </trans-unit>
+            <trans-unit id="13">
+                <source>diff.in.year</source>
+                <target>1 年後|%count% 年後</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/translations/time.zh_TW.xliff
+++ b/Resources/translations/time.zh_TW.xliff
@@ -1,0 +1,59 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>diff.ago.year</source>
+                <target>1 年以前|%count% 年以前</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>diff.ago.month</source>
+                <target>1 個月以前|%count% 個月以前</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>diff.ago.day</source>
+                <target>1 天以前|%count% 天以前</target>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>diff.ago.hour</source>
+                <target>1 個小時以前|%count% 小時以前</target>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>diff.ago.minute</source>
+                <target>1 分鐘以前|%count% 分鐘以前</target>
+            </trans-unit>
+            <trans-unit id="6">
+                <source>diff.ago.second</source>
+                <target>1 秒以前|%count% 秒以前</target>
+            </trans-unit>
+            <trans-unit id="7">
+                <source>diff.empty</source>
+                <target>剛才</target>
+            </trans-unit>
+            <trans-unit id="8">
+                <source>diff.in.second</source>
+                <target>1 秒後|%count% 秒後</target>
+            </trans-unit>
+            <trans-unit id="9">
+                <source>diff.in.hour</source>
+                <target>1 個小時後|%count% 個小時後</target>
+            </trans-unit>
+            <trans-unit id="10">
+                <source>diff.in.minute</source>
+                <target>1 分鐘後|%count% 分鐘後</target>
+            </trans-unit>
+            <trans-unit id="11">
+                <source>diff.in.day</source>
+                <target>1 天後|%count% 天後</target>
+            </trans-unit>
+            <trans-unit id="12">
+                <source>diff.in.month</source>
+                <target>1 個月後|%count% 個月後</target>
+            </trans-unit>
+            <trans-unit id="13">
+                <source>diff.in.year</source>
+                <target>1 年後|%count% 年後</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>


### PR DESCRIPTION
Issues
- "意钱" is possibly a typo. Should be "以前"
- I have never heard of "恩 等 1 秒" and I don't think it is grammatically correct.
- "cn" is not ISO639-1 language code. The correct one should be zh.

Also added 4char codes (simplified chinese, zh_CN) and traditional chinese translation (zh_TW, zh_HK)
