### PR TITLE
Updates twig extension to work with twig 1.12-2.0

### DIFF
--- a/Twig/Extension/TimeExtension.php
+++ b/Twig/Extension/TimeExtension.php
@@ -34,18 +34,22 @@ class TimeExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            'time_diff'  => new \Twig_Function_Method($this, 'diff', array(
-                'is_safe' => array('html')
-            ))
+            new \Twig_SimpleFunction(
+                    'time_diff', 
+                    array($this, 'diff'), 
+                    array('is_safe' => array('html'))
+                ),
         );
     }
 
     public function getFilters()
     {
         return array(
-            'ago' => new \Twig_Filter_Method($this, 'diff', array(
-                'is_safe' => array('html')
-            ))
+            new \Twig_SimpleFilter(
+                    'ago', 
+                    array($this, 'diff'), 
+                    array('is_safe' => array('html'))
+                ),
         );
     }
 


### PR DESCRIPTION
This extension has relied on \Twig_Function_Method and \Twig_Filter_Method,
which are both deprecated as of 1.12. Replacing them with the respective
\Twig_SimpleFunction and \Twig_SimpleFilter makes the extension forward-
compatible.