### PR TITLE
Precision time settings to filter

### DIFF
--- a/DateTimeFormatter.php
+++ b/DateTimeFormatter.php
@@ -52,7 +52,7 @@ class DateTimeFormatter
                     return $this->doGetDiffMessage($count, $diff->invert, $unit);
                 }
             } else {
-                if( in_array($attribute, $precision) && 0 !== $count ) {
+                if( in_array($attribute, $precision) === true && 0 !== $count ) {
                     $diffMessage .= ($index === 0 ? '' : ' ').$this->doGetDiffMessage($count, $diff->invert, $unit, $firtsMessage);
 
                     $firtsMessage = false;

--- a/Resources/translations/time.en.xliff
+++ b/Resources/translations/time.en.xliff
@@ -54,6 +54,26 @@
                 <source>diff.in.year</source>
                 <target>in 1 year|in %count% years</target>
             </trans-unit>
+            <trans-unit id="14">
+                <source>diff.month</source>
+                <target>1 month|%count% months</target>
+            </trans-unit>
+            <trans-unit id="15">
+                <source>diff.day</source>
+                <target>1 day|%count% days</target>
+            </trans-unit>
+            <trans-unit id="16">
+                <source>diff.hour</source>
+                <target>1 hour|%count% hours</target>
+            </trans-unit>
+            <trans-unit id="17">
+                <source>diff.minute</source>
+                <target>1 minute|%count% minutes</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>diff.second</source>
+                <target>1 second|%count% seconds</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/time.es.xliff
+++ b/Resources/translations/time.es.xliff
@@ -54,6 +54,26 @@
                 <source>diff.in.year</source>
                 <target>en 1 año|en %count% años</target>
             </trans-unit>
+            <trans-unit id="14">
+                <source>diff.month</source>
+                <target>1 mes|%count% meses</target>
+            </trans-unit>
+            <trans-unit id="15">
+                <source>diff.day</source>
+                <target>1 día|%count% días</target>
+            </trans-unit>
+            <trans-unit id="16">
+                <source>diff.hour</source>
+                <target>1 hora|%count% horas</target>
+            </trans-unit>
+            <trans-unit id="17">
+                <source>diff.minute</source>
+                <target>1 minuto|%count% minutos</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>diff.second</source>
+                <target>1 segundo|%count% segundos</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Templating/Helper/TimeHelper.php
+++ b/Templating/Helper/TimeHelper.php
@@ -24,12 +24,12 @@ class TimeHelper extends Helper
      *
      * @return string
      */
-    public function diff($from, $to = null)
+    public function diff($from, $to = null, $precision = array())
     {
         $from = $this->getDatetimeObject($from);
         $to = $this->getDatetimeObject($to);
 
-        return $this->formatter->formatDiff($from, $to);
+        return $this->formatter->formatDiff($from, $to, $precision);
     }
 
     /**

--- a/Tests/DateTimeFormatterTest.php
+++ b/Tests/DateTimeFormatterTest.php
@@ -23,25 +23,38 @@ class DateTimeFormatterTest extends \PHPUnit_Framework_TestCase
     {
         $tests = array(
             array('- 5 years', 'now', 'diff.ago.year'),
+            array('- 5 years', 'now', 'diff.ago.year',array('y')),
             array('- 10 months', 'now', 'diff.ago.month'),
+            array('- 10 months', 'now', 'diff.ago.month',array('y','m')),
             array('- 15 days', 'now', 'diff.ago.day'),
+            array('- 15 days', 'now', 'diff.ago.day',array('y','m','d')),
             array('- 20 hours', 'now', 'diff.ago.hour'),
+            array('- 20 hours', 'now', 'diff.ago.hour',array('y','m','d','h')),
             array('- 25 minutes', 'now', 'diff.ago.minute'),
+            array('- 25 minutes', 'now', 'diff.ago.minute',array('y','m','d','h','i')),
             array('- 30 seconds', 'now', 'diff.ago.second'),
+            array('- 30 seconds', 'now', 'diff.ago.second',array('y','m','d','h','i','s')),
             array('now', 'now', 'diff.empty'),
             array('+ 30 seconds', 'now', 'diff.in.second'),
+            array('+ 30 seconds', 'now', 'diff.in.second',array('s')),
             array('+ 25 minutes', 'now', 'diff.in.minute'),
+            array('+ 25 minutes', 'now', 'diff.in.minute',array('i','s')),
             array('+ 20 hours', 'now', 'diff.in.hour'),
+            array('+ 20 hours', 'now', 'diff.in.hour',array('h','i','s')),
             array('+ 15 days', 'now', 'diff.in.day'),
+            array('+ 15 days', 'now', 'diff.in.day',array('d','h','i','s')),
             array('+ 10 months', 'now', 'diff.in.month'),
-            array('+ 5 years', 'now', 'diff.in.year')
+            array('+ 10 months', 'now', 'diff.in.month',array('m','d','h','i','s')),
+            array('+ 5 years', 'now', 'diff.in.year'),
+            array('+ 5 years', 'now', 'diff.in.year',array('y','m','d','h','i','s')),
+            array('- 5 years 1 month 2 days', 'now', 'diff.ago.year diff.month diff.day', array('y','m','d'))
         );
 
         foreach ($tests as $test) {
             $from = new \Datetime(date('Y-m-d H:i:s', strtotime($test[0])));
             $to = new \Datetime(date('Y-m-d H:i:s', strtotime($test[1])));
 
-            $this->assertEquals($test[2], $this->formatter->formatDiff($from, $to));
+            $this->assertEquals($test[2], $this->formatter->formatDiff($from, $to, ( array_key_exists(3, $test) === true ? $test[3] : array() ) ));
         }
     }
 

--- a/Twig/Extension/TimeExtension.php
+++ b/Twig/Extension/TimeExtension.php
@@ -35,8 +35,8 @@ class TimeExtension extends \Twig_Extension
     {
         return array(
             new \Twig_SimpleFunction(
-                    'time_diff', 
-                    array($this, 'diff'), 
+                    'time_diff',
+                    array($this, 'diff'),
                     array('is_safe' => array('html'))
                 ),
         );
@@ -46,16 +46,16 @@ class TimeExtension extends \Twig_Extension
     {
         return array(
             new \Twig_SimpleFilter(
-                    'ago', 
-                    array($this, 'diff'), 
+                    'ago',
+                    array($this, 'diff'),
                     array('is_safe' => array('html'))
                 ),
         );
     }
 
-    public function diff($since = null, $to = null)
+    public function diff($since = null, $to = null, $precision = array())
     {
-        return $this->helper->diff($since, $to);
+        return $this->helper->diff($since, $to, $precision);
     }
 
     /**


### PR DESCRIPTION
Precision time settings ['y', 'm', 'd', 'h', 'i', 's'] added to twig filter, which will allow define if year, month day, hour, minute and secon is shown in the same string.

Example of Use in twig: 
```twig
{# timeObject is a date more than now #}

{# Filter method #}
{{ timeObject|ago(null,['y','m','d']) }}

{# function method #}
{{ time_diff(timeObject,null,['y','m','d']) }}

{# outpu: in 3 years 7 months 2 days #}
```