### PR TITLE
Fix the german translation

### DIFF
--- a/Resources/translations/time.de.xliff
+++ b/Resources/translations/time.de.xliff
@@ -4,27 +4,27 @@
         <body>
             <trans-unit id="1">
                 <source>diff.ago.year</source>
-                <target>vor 1 Jahr|vor %count% Jahren</target>
+                <target>vor einem Jahr|vor %count% Jahren</target>
             </trans-unit>
             <trans-unit id="2">
                 <source>diff.ago.month</source>
-                <target>vor 1 Monat|vor %count% Monaten</target>
+                <target>vor einem Monat|vor %count% Monaten</target>
             </trans-unit>
             <trans-unit id="3">
                 <source>diff.ago.day</source>
-                <target>vor 1 Tag|vor %count% Tagen</target>
+                <target>vor einem Tag|vor %count% Tagen</target>
             </trans-unit>
             <trans-unit id="4">
                 <source>diff.ago.hour</source>
-                <target>vor 1 Stunde|vor %count% Stunden</target>
+                <target>vor einer Stunde|vor %count% Stunden</target>
             </trans-unit>
             <trans-unit id="5">
                 <source>diff.ago.minute</source>
-                <target>vor 1 Minute|vor %count% Minuten</target>
+                <target>vor einer Minute|vor %count% Minuten</target>
             </trans-unit>
             <trans-unit id="6">
                 <source>diff.ago.second</source>
-                <target>vor 1 Sekunde|vor %count% Sekunden</target>
+                <target>vor einer Sekunde|vor %count% Sekunden</target>
             </trans-unit>
             <trans-unit id="7">
                 <source>diff.empty</source>
@@ -32,27 +32,27 @@
             </trans-unit>
             <trans-unit id="8">
                 <source>diff.in.second</source>
-                <target>in 1 Sekunde|in %count% Sekunden</target>
+                <target>in einer Sekunde|in %count% Sekunden</target>
             </trans-unit>
             <trans-unit id="9">
                 <source>diff.in.hour</source>
-                <target>in 1 Stunde|in %count% Stunden</target>
+                <target>in einer Stunde|in %count% Stunden</target>
             </trans-unit>
             <trans-unit id="10">
                 <source>diff.in.minute</source>
-                <target>in 1 Minute|in %count% Minuten</target>
+                <target>in einer Minute|in %count% Minuten</target>
             </trans-unit>
             <trans-unit id="11">
                 <source>diff.in.day</source>
-                <target>in 1 Tag|in %count% Tagen</target>
+                <target>in einem Tag|in %count% Tagen</target>
             </trans-unit>
             <trans-unit id="12">
                 <source>diff.in.month</source>
-                <target>in 1 Monat|in %count% Monaten</target>
+                <target>in einem Monat|in %count% Monaten</target>
             </trans-unit>
             <trans-unit id="13">
                 <source>diff.in.year</source>
-                <target>in 1 Jahr|in %count% Jahren</target>
+                <target>in einem Jahr|in %count% Jahren</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
It is not correct to say "vor 1 Minute". It should be "vor einer Minute".