### PR TITLE
Fix typo in time.uk.xliff

### DIFF
--- a/Resources/translations/time.uk.xliff
+++ b/Resources/translations/time.uk.xliff
@@ -8,7 +8,7 @@
             </trans-unit>
             <trans-unit id="2">
                 <source>diff.ago.month</source>
-                <target>%count% мiсяць тому|%count% мiсяця тому|%count% мiсяцiв тому</target>
+                <target>%count% мiсяць тому|%count% мiсяцi тому|%count% мiсяцiв тому</target>
             </trans-unit>
             <trans-unit id="3">
                 <source>diff.ago.day</source>


### PR DESCRIPTION
Fix typo in ukrainian translation.

For past times wrong label for months "мiсяця тому" need to replace to "мiсяцi тому".
For future times translation for months correct.