### PR TITLE
Revert method trans to transChoice to keep the compatibility with Sf 3.*

### DIFF
--- a/DateTimeFormatter.php
+++ b/DateTimeFormatter.php
@@ -79,7 +79,7 @@ class DateTimeFormatter
     {
         $id = sprintf('diff.%s.%s', $invert ? 'ago' : 'in', $unit);
 
-        return $this->translator->trans($id, array('%count%' => $count), 'time');
+        return $this->translator->transChoice($id, $count, array(), 'time');
     }
 
     /**


### PR DESCRIPTION
Referred issue : https://github.com/KnpLabs/KnpTimeBundle/issues/112

I think we need to revert method trans to transChoice to keep the compatibility with Symfony 3.*.

The method transChoice in Symfony 4.2 is not removed but only deprecated so It works with this version (I think this method will be removed in the next major version of Symfony). 

In my opinion, if you want to keep this change, this bundle should change his major version v2.* and keep the v1.* for Symfony v1.3.* (to avoid this kind of issue).

Tested with Symfony 3.4.22 & 4.2
