### PR TITLE
Squashed commit of the following:

### DIFF
--- a/Templating/Helper/TimeHelper.php
+++ b/Templating/Helper/TimeHelper.php
@@ -52,6 +52,30 @@ class TimeHelper extends Helper
 
         return new DateTime($datetime);
     }
+    
+    /**
+     * @param $maxDiff
+     */
+    public function setMaxDiff($maxDiff)
+    {
+        $this->formatter->setMaxDiff($maxDiff);
+    }
+    
+    /**
+     * @param $maxDiffUnit
+     */
+    public function setMaxDiffUnit($maxDiffUnit)
+    {
+        $this->formatter->setMaxDiffUnit($maxDiffUnit);
+    }
+    
+    /**
+     * @param $dateFormat
+     */
+    public function setDateFormat($dateFormat)
+    {
+        $this->formatter->setDateFormat($dateFormat);
+    }
 
     public function getName()
     {

--- a/Tests/DateTimeFormatterTest.php
+++ b/Tests/DateTimeFormatterTest.php
@@ -2,8 +2,14 @@
 
 namespace Knp\Bundle\TimeBundle;
 
+use DateInterval;
+use DateTime;
+
 class DateTimeFormatterTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var DateTimeFormatter
+     */
     protected $formatter;
 
     public function setUp()
@@ -67,5 +73,45 @@ class DateTimeFormatterTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('InvalidArgumentException');
 
         $this->formatter->getDiffMessage(1, true, 'patate');
+    }
+    
+    public function testFormatDiffMaxDiffSet()
+    {
+        $this->formatter->setMaxDiff(1);
+        $this->formatter->setMaxDiffUnit('day');
+        $format = 'd/m/Y';
+        $this->formatter->setDateFormat($format);
+        
+        $now = new DateTime();
+        
+        $from = (clone $now)->sub(new DateInterval('P2D'));
+        $to = clone $now;
+        $result = $this->formatter->formatDiff($from, $to);
+        $this->assertEquals($from->format($format), $result);
+    
+        $from = (clone $now)->sub(new DateInterval('PT10H'));
+        $to = clone $now;
+        
+        $result = $this->formatter->formatDiff($from, $to);
+        $this->assertEquals('diff.ago.hour', $result);
+    
+        //Other tests with 1 month
+        $this->formatter->setMaxDiff(1);
+        $this->formatter->setMaxDiffUnit('month');
+    
+        $from = (clone $now)->sub(new DateInterval('P2D'));
+        $to = clone $now;
+        $result = $this->formatter->formatDiff($from, $to);
+        $this->assertEquals('diff.ago.day', $result);
+        
+        $from = (clone $now)->sub(new DateInterval('P1M'));
+        $to = clone $now;
+        $result = $this->formatter->formatDiff($from, $to);
+        $this->assertEquals('diff.ago.month', $result);
+    
+        $from = (clone $now)->sub(new DateInterval('P35D'));
+        $to = clone $now;
+        $result = $this->formatter->formatDiff($from, $to);
+        $this->assertEquals($from->format($format), $result);
     }
 }

--- a/Twig/Extension/TimeExtension.php
+++ b/Twig/Extension/TimeExtension.php
@@ -50,7 +50,28 @@ class TimeExtension extends \Twig_Extension
                     array($this, 'diff'), 
                     array('is_safe' => array('html'))
                 ),
+            new \Twig_SimpleFilter(
+                'diffmax',
+                array($this, 'diffmax'),
+                array('is_safe' => array('html'))
+            ),
         );
+    }
+    
+    /**
+     * @param $date \DateTime first argument, the value we want to display
+     * @param null $maxDiff
+     * @param string $dateFormat
+     * @param string $maxDiffUnit
+     *
+     * @return \DateTime
+     */
+    public function diffmax($date, $maxDiff = null, $dateFormat = 'd/m/Y', $maxDiffUnit = 'day')
+    {
+        $this->helper->setMaxDiff($maxDiff);
+        $this->helper->setMaxDiffUnit($maxDiffUnit);
+        $this->helper->setDateFormat($dateFormat);
+        return $date;
     }
 
     public function diff($since = null, $to = null)


### PR DESCRIPTION
close #78 

Addition of a "maxdiff" filter (I had no idea to name it, if you have a better name, let me know) to limit the Date difference to display the "ago" format.

I made that PR quickly because I wanted to have that behaviour in an app and had no idea how to do that in twig only and i saw a related issue.

It's one of my first PR for an open source project, so if there's any problem with the PR (code or this description), let me know.

Examples:
(in french, sorry. For non-french, It says "5 hours ago")
![](https://i.imgur.com/FhIQfQJ.png)
with the code
`{{ chapter.publishedAt|diffmax(15, 'd/m/Y', 'hour')|ago }}`
(The filters order doesn't seem to matter)