### PR TITLE
Use transChoice for Symfony <4.2

### DIFF
--- a/DateTimeFormatter.php
+++ b/DateTimeFormatter.php
@@ -79,7 +79,12 @@ class DateTimeFormatter
     {
         $id = sprintf('diff.%s.%s', $invert ? 'ago' : 'in', $unit);
 
-        return $this->translator->trans($id, array('%count%' => $count), 'time');
+        // check for Symfony >= 4.2
+        if (class_exists('Symfony\Component\Translation\Formatter\IntlFormatter')) {
+            return $this->translator->trans($id, array('%count%' => $count), 'time');
+        } else {
+            return $this->translator->transChoice($id, $count, array('%count%' => $count), 'time');
+        }
     }
 
     /**


### PR DESCRIPTION
On Symfony 3, the translation does not happen as intended (details in #112). This PR is an alternate proposal to #114. It avoids the deprecation notice for Symfony >=4.2 and uses `transChoice()` for older versions.