### PR TITLE
Fix Symfony 4.2+ translator class_exists

### DIFF
--- a/DateTimeFormatter.php
+++ b/DateTimeFormatter.php
@@ -2,6 +2,7 @@
 
 namespace Knp\Bundle\TimeBundle;
 
+use Symfony\Contracts\Translation\LocaleAwareInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 use DatetimeInterface;
 
@@ -80,7 +81,7 @@ class DateTimeFormatter
         $id = sprintf('diff.%s.%s', $invert ? 'ago' : 'in', $unit);
 
         // check for Symfony >= 4.2
-        if (class_exists('Symfony\Component\Translation\Formatter\IntlFormatter')) {
+        if ($this->translator instanceof LocaleAwareInterface) {
             return $this->translator->trans($id, array('%count%' => $count), 'time');
         } else {
             return $this->translator->transChoice($id, $count, array('%count%' => $count), 'time');


### PR DESCRIPTION
Fixes #112 and #115  and removes the impact of `__autoload` and function call by using `class_exists()` used in #117 

The `LocaleAwareInterface` was added in `Symfony 4.2.0+` and extends the [`TranslatorInterface`](https://github.com/symfony/translation/blob/4.2/TranslatorInterface.php) service that is type-hinted in the `DateTimeFormatter` constructor. Where the `TranslatorInterface` is also depreciated in Symfony 4.2 in favor of using the new [`Symfony\Contracts\Translation\TranslatorInterface`](https://github.com/symfony/contracts/blob/master/Translation/TranslatorInterface.php)

The inclusion of the interface in the imports will not cause errors in `Symfony <= 4.1` or invoke `__autoload`.