### PR TITLE
use namespaced twig classes

### DIFF
--- a/Twig/Extension/TimeExtension.php
+++ b/Twig/Extension/TimeExtension.php
@@ -5,6 +5,7 @@ namespace Knp\Bundle\TimeBundle\Twig\Extension;
 use Knp\Bundle\TimeBundle\Templating\Helper\TimeHelper;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
+use Twig\TwigFunction;
 
 /*
  * This file is part of the Symfony package.
@@ -36,7 +37,7 @@ class TimeExtension extends AbstractExtension
     public function getFunctions()
     {
         return array(
-            new TwigFilter(
+            new TwigFunction(
                     'time_diff', 
                     array($this, 'diff'), 
                     array('is_safe' => array('html'))

--- a/Twig/Extension/TimeExtension.php
+++ b/Twig/Extension/TimeExtension.php
@@ -3,6 +3,8 @@
 namespace Knp\Bundle\TimeBundle\Twig\Extension;
 
 use Knp\Bundle\TimeBundle\Templating\Helper\TimeHelper;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
 
 /*
  * This file is part of the Symfony package.
@@ -17,7 +19,7 @@ use Knp\Bundle\TimeBundle\Templating\Helper\TimeHelper;
  *
  * @author Fabien Potencier <fabien.potencier@symfony-project.com>
  */
-class TimeExtension extends \Twig_Extension
+class TimeExtension extends AbstractExtension
 {
     protected $helper;
 
@@ -34,7 +36,7 @@ class TimeExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            new \Twig_SimpleFunction(
+            new TwigFilter(
                     'time_diff', 
                     array($this, 'diff'), 
                     array('is_safe' => array('html'))
@@ -45,7 +47,7 @@ class TimeExtension extends \Twig_Extension
     public function getFilters()
     {
         return array(
-            new \Twig_SimpleFilter(
+            new TwigFilter(
                     'ago', 
                     array($this, 'diff'), 
                     array('is_safe' => array('html'))


### PR DESCRIPTION
made a mistake in the previous pr, this should be okay now.

this fixes #125, fixes #122 and makes the bundle work for twig 3.x.

see https://symfony.com/blog/preparing-your-applications-for-twig-3