### PR TITLE
bumping php & symfony version dependencies and making code updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,45 +1,38 @@
 language: php
-
 sudo: false
-
 cache:
-  directories:
-    - $HOME/.composer/cache
+    directories:
+        - $HOME/.composer/cache/files
+        - $HOME/symfony-bridge/.phpunit
 
 env:
-  global:
-    - SYMFONY_VERSION=""
-    - TWIG_VERSION=""
-
-php:
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
-  - hhvm
+    global:
+        - PHPUNIT_FLAGS="-v"
+        - SYMFONY_PHPUNIT_DIR="$HOME/symfony-bridge/.phpunit"
+        - SYMFONY_REQUIRE='>=2.8'
 
 matrix:
-  include:
-    - php: 5.6
-      env: SYMFONY_VERSION="2.3.x"
-    - php: 5.6
-      env: SYMFONY_VERSION="2.8.x symfony/phpunit-bridge:^2.7"
-    - php: 5.6
-      env: SYMFONY_VERSION="3.0.x"
-    - php: 5.6
-      env: SYMFONY_VERSION="dev-master"
-    - php: 5.6
-      env: TWIG_VERSION="2.0.x-dev"
-    - php: 7.1
-      env: SYMFONY_VERSION="4.0.x@beta"
-  fast_finish: true
-  allow_failures:
-    - php: hhvm
-    - env: TWIG_VERSION="2.0.x-dev"
-    - env: SYMFONY_VERSION="dev-master"
+    fast_finish: true
+    include:
+        - php: 7.1
+        - php: 7.2
+        - php: 7.3
+          env: deps=low
 
-before_install: if [[ "$SYMFONY_VERSION" != "" ]]; then composer require --no-update symfony/symfony:${SYMFONY_VERSION}; fi
+before_install:
+    - phpenv config-rm xdebug.ini || true
+    - composer global require --no-progress --no-scripts --no-plugins symfony/flex dev-master
 
-install: composer update --prefer-dist
+install:
+    - |
+      if [[ $deps = low ]]; then
+          export SYMFONY_DEPRECATIONS_HELPER=weak
+          composer update --prefer-dist --prefer-lowest --prefer-stable
+      else
+          composer update --prefer-dist
+      fi
+    - ./vendor/bin/simple-phpunit install
 
-script: vendor/bin/phpunit
+script:
+    - composer validate --strict --no-check-lock
+    - ./vendor/bin/simple-phpunit $PHPUNIT_FLAGS

--- a/DateTimeFormatter.php
+++ b/DateTimeFormatter.php
@@ -2,7 +2,7 @@
 
 namespace Knp\Bundle\TimeBundle;
 
-use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use DatetimeInterface;
 
 class DateTimeFormatter

--- a/Tests/DateTimeFormatterTest.php
+++ b/Tests/DateTimeFormatterTest.php
@@ -2,20 +2,20 @@
 
 namespace Knp\Bundle\TimeBundle;
 
-class DateTimeFormatterTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class DateTimeFormatterTest extends TestCase
 {
     protected $formatter;
 
-    public function setUp()
+    public function setUp(): void
     {
-        $translator = $this->getMockBuilder('Symfony\Component\Translation\Translator')
+        $translator = $this->getMockBuilder(TranslatorInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
         $translator->expects($this->any())
             ->method('trans')
-            ->will($this->returnArgument(0));
-        $translator->expects($this->any())
-            ->method('transChoice')
             ->will($this->returnArgument(0));
 
         $this->formatter = new DateTimeFormatter($translator);
@@ -55,17 +55,19 @@ class DateTimeFormatterTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     */
     public function testGetDiffMessageThrowsAnExceptionIfTheDiffIsEmpty()
     {
-        $this->setExpectedException('InvalidArgumentException');
-
         $this->formatter->getDiffMessage(0, true, 'day');
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     */
     public function testGetDiffMessageThrowsAnExceptionIfTheDiffUnitIsNotSupported()
     {
-        $this->setExpectedException('InvalidArgumentException');
-
         $this->formatter->getDiffMessage(1, true, 'patate');
     }
 }

--- a/Tests/DateTimeFormatterTest.php
+++ b/Tests/DateTimeFormatterTest.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace Knp\Bundle\TimeBundle;
+namespace Knp\Bundle\TimeBundle\Tests;
 
+use Knp\Bundle\TimeBundle\DateTimeFormatter;
 use PHPUnit\Framework\TestCase;
 use Symfony\Contracts\Translation\TranslatorInterface;
 

--- a/Tests/IntegrationTest.php
+++ b/Tests/IntegrationTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Knp\Bundle\TimeBundle\Tests;
+
+use Knp\Bundle\TimeBundle\KnpTimeBundle;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LogLevel;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Bundle\TwigBundle\TwigBundle;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\HttpKernel\Log\Logger;
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+
+class IntegrationTest extends TestCase
+{
+    public function testServiceWiring()
+    {
+        $kernel = new TimeBundleIntegrationTestKernel();
+        $kernel->boot();
+        $container = $kernel->getContainer();
+
+        $result = $container->get('twig')->render('@integration_test/template.twig', [
+            'yesterday' => (new \DateTime('-1 day'))
+        ]);
+        $this->assertSame('1 day ago', $result);
+    }
+}
+
+abstract class AbstractTimeBundleIntegrationTestKernel extends Kernel
+{
+    use MicroKernelTrait;
+
+    public function __construct()
+    {
+        parent::__construct('test', true);
+    }
+    public function registerBundles()
+    {
+        return [
+            new FrameworkBundle(),
+            new TwigBundle(),
+            new KnpTimeBundle()
+        ];
+    }
+    protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader)
+    {
+        $container->loadFromExtension('framework', [
+            'secret' => 'foo',
+        ]);
+        $container->loadFromExtension('twig', [
+            'paths' => [
+                __DIR__.'/fixtures' => 'integration_test',
+            ],
+            'strict_variables' => true,
+            'exception_controller' => null,
+        ]);
+        // avoid logging request logs
+        $container->register('logger', Logger::class)
+            ->setArgument(0, LogLevel::EMERGENCY);
+    }
+    public function getCacheDir()
+    {
+        return sys_get_temp_dir().'/cache'.spl_object_hash($this);
+    }
+    public function getLogDir()
+    {
+        return sys_get_temp_dir().'/logs'.spl_object_hash($this);
+    }
+}
+if (method_exists(AbstractTimeBundleIntegrationTestKernel::class, 'configureRouting')) {
+    class TimeBundleIntegrationTestKernel extends AbstractTimeBundleIntegrationTestKernel {
+        protected function configureRouting(RoutingConfigurator $routes): void
+        {
+            $routes->add('/foo', 'kernel:'.(parent::VERSION_ID >= 40100 ? ':' : '').'renderFoo');
+        }
+    }
+} else {
+    class TimeBundleIntegrationTestKernel extends AbstractTimeBundleIntegrationTestKernel {
+        protected function configureRoutes(RoutingConfigurator $routes)
+        {
+            $routes->add('/foo', 'kernel:'.(parent::VERSION_ID >= 40100 ? ':' : '').'renderFoo');
+        }
+    }
+}

--- a/Tests/fixtures/template.twig
+++ b/Tests/fixtures/template.twig
@@ -1,0 +1,1 @@
+{{ yesterday|ago }}

--- a/composer.json
+++ b/composer.json
@@ -18,15 +18,15 @@
     ],
 
     "require": {
-        "php":                          ">=5.6",
-        "symfony/dependency-injection": "~3.4|~4.0|^5.0",
-        "symfony/templating":           "~3.4|~4.0|^5.0",
-        "symfony/translation":          "~3.4|~4.0|^5.0",
-        "symfony/config":               "~3.4|~4.0|^5.0"
+        "php":                          "^7.1.3",
+        "symfony/dependency-injection": "~3.4|^4.3|^5.0",
+        "symfony/templating":           "~3.4|^4.3|^5.0",
+        "symfony/translation":          "~3.4|^4.3|^5.0",
+        "symfony/config":               "~3.4|^4.3|^5.0"
     },
 
     "require-dev": {
-        "phpunit/phpunit": "^4.8|^5.0"
+        "symfony/phpunit-bridge": "^4.3|^5.0"
     },
 
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -21,12 +21,14 @@
         "php":                          "^7.1.3",
         "symfony/dependency-injection": "~3.4|^4.3|^5.0",
         "symfony/templating":           "~3.4|^4.3|^5.0",
-        "symfony/translation":          "~3.4|^4.3|^5.0",
+        "symfony/translation":          "^4.3|^5.0",
         "symfony/config":               "~3.4|^4.3|^5.0"
     },
 
     "require-dev": {
-        "symfony/phpunit-bridge": "^4.3|^5.0"
+        "symfony/framework-bundle": "^4.3|^5.0",
+        "symfony/phpunit-bridge": "^4.3|^5.0",
+        "symfony/twig-bundle": "^4.3|^5.0"
     },
 
     "suggest": {
@@ -38,6 +40,8 @@
             "Knp\\Bundle\\TimeBundle": ""
         }
     },
+
+    "minimum-stability": "dev",
 
     "target-dir": "Knp/Bundle/TimeBundle",
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,18 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-        colors="true"
-        convertErrorsToExceptions="true"
-        convertNoticesToExceptions="true"
-        convertWarningsToExceptions="true"
-        processIsolation="false"
-        stopOnFailure="false"
-        syntaxCheck="false"
-        bootstrap="./vendor/autoload.php">
+
+<!-- http://phpunit.de/manual/4.1/en/appendixes.configuration.html -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.3/phpunit.xsd"
+         backupGlobals="false"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         failOnRisky="true"
+         failOnWarning="true"
+>
+    <php>
+        <server name="SYMFONY_PHPUNIT_VERSION" value="7.5" />
+    </php>
 
     <testsuites>
-        <testsuite name="KnpTimeBundle Test Suite">
-            <directory>./Tests</directory>
+        <testsuite name="Project Test Suite">
+            <directory>tests</directory>
         </testsuite>
     </testsuites>
 
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory>.</directory>
+            <exclude>
+                <directory>tests</directory>
+                <directory>vendor</directory>
+            </exclude>
+        </whitelist>
+    </filter>
 </phpunit>


### PR DESCRIPTION
Follows #127 - we need to get the test suite in order. To do that, it's time to bump to PHP 7.1 and only supported Symfony versions.
