### PR TITLE
Remove symfony/templating as a hard dependency

### DIFF
--- a/DateTimeFormatter.php
+++ b/DateTimeFormatter.php
@@ -3,6 +3,7 @@
 namespace Knp\Bundle\TimeBundle;
 
 use Symfony\Contracts\Translation\TranslatorInterface;
+use DateTime;
 use DatetimeInterface;
 
 class DateTimeFormatter
@@ -73,6 +74,24 @@ class DateTimeFormatter
         }
 
         return $this->doGetDiffMessage($count, $invert, $unit);
+    }
+
+    /**
+     * Returns a DateTime instance for the given datetime
+     *
+     * @param mixed $datetime
+     */
+    public function getDatetimeObject($datetime = null): DateTimeInterface
+    {
+        if ($datetime instanceof DateTimeInterface) {
+            return $datetime;
+        }
+
+        if (is_int($datetime)) {
+            $datetime = date('Y-m-d H:i:s', $datetime);
+        }
+
+        return new DateTime($datetime);
     }
 
     protected function doGetDiffMessage($count, $invert, $unit)

--- a/DateTimeFormatter.php
+++ b/DateTimeFormatter.php
@@ -81,17 +81,17 @@ class DateTimeFormatter
      *
      * @param mixed $datetime
      */
-    public function getDatetimeObject($datetime = null): DateTimeInterface
+    public function getDateTimeObject($dateTime = null): DateTimeInterface
     {
-        if ($datetime instanceof DateTimeInterface) {
-            return $datetime;
+        if ($dateTime instanceof DateTimeInterface) {
+            return $dateTime;
         }
 
-        if (is_int($datetime)) {
-            $datetime = date('Y-m-d H:i:s', $datetime);
+        if (is_int($dateTime)) {
+            $dateTime = date('Y-m-d H:i:s', $dateTime);
         }
 
-        return new DateTime($datetime);
+        return new DateTime($dateTime);
     }
 
     protected function doGetDiffMessage($count, $invert, $unit)

--- a/DependencyInjection/KnpTimeExtension.php
+++ b/DependencyInjection/KnpTimeExtension.php
@@ -6,13 +6,22 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\Templating\Helper\Helper;
+use Twig\Extension\AbstractExtension;
 
 class KnpTimeExtension extends Extension
 {
     public function load(array $configs, ContainerBuilder $container)
     {
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
-        $loader->load('templating.xml');
-        $loader->load('twig.xml');
+        $loader->load('services.xml');
+
+        if (class_exists(AbstractExtension::class)) {
+            $loader->load('twig.xml');
+        }
+
+        if (class_exists(Helper::class)) {
+            $loader->load('templating.xml');
+        }
     }
 }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="time.datetime_formatter.class">Knp\Bundle\TimeBundle\DateTimeFormatter</parameter>
+    </parameters>
+
+    <services>
+        <service id="time.datetime_formatter" class="%time.datetime_formatter.class%">
+            <argument type="service" id="translator"/>
+        </service>
+    </services>
+</container>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -12,5 +12,7 @@
         <service id="time.datetime_formatter" class="%time.datetime_formatter.class%">
             <argument type="service" id="translator"/>
         </service>
+
+        <service id="Knp\Bundle\TimeBundle\DateTimeFormatter" alias="time.datetime_formatter" />
     </services>
 </container>

--- a/Resources/config/templating.xml
+++ b/Resources/config/templating.xml
@@ -6,14 +6,9 @@
 
     <parameters>
         <parameter key="time.templating.helper.time.class">Knp\Bundle\TimeBundle\Templating\Helper\TimeHelper</parameter>
-        <parameter key="time.datetime_formatter.class">Knp\Bundle\TimeBundle\DateTimeFormatter</parameter>
     </parameters>
 
     <services>
-        <service id="time.datetime_formatter" class="%time.datetime_formatter.class%">
-            <argument type="service" id="translator"/>
-        </service>
-
         <service id="time.templating.helper.time" class="%time.templating.helper.time.class%">
             <argument type="service" id="time.datetime_formatter" />
             <tag name="templating.helper" alias="time" />

--- a/Resources/config/twig.xml
+++ b/Resources/config/twig.xml
@@ -10,7 +10,7 @@
 
     <services>
         <service id="time.twig.extension.time" class="%time.twig.extension.time.class%" public="false">
-            <argument type="service" id="time.templating.helper.time" />
+            <argument type="service" id="time.datetime_formatter" />
             <tag name="twig.extension" />
         </service>
     </services>

--- a/Templating/Helper/TimeHelper.php
+++ b/Templating/Helper/TimeHelper.php
@@ -4,8 +4,6 @@ namespace Knp\Bundle\TimeBundle\Templating\Helper;
 
 use Symfony\Component\Templating\Helper\Helper;
 use Knp\Bundle\TimeBundle\DateTimeFormatter;
-use DateTime;
-use DateTimeInterface;
 
 class TimeHelper extends Helper
 {
@@ -27,30 +25,18 @@ class TimeHelper extends Helper
      */
     public function diff($from, $to = null)
     {
-        $from = $this->getDatetimeObject($from);
-        $to = $this->getDatetimeObject($to);
+        $from = $this->formatter->getDatetimeObject($from);
+        $to = $this->formatter->getDatetimeObject($to);
 
         return $this->formatter->formatDiff($from, $to);
     }
 
     /**
-     * Returns a DateTime instance for the given datetime
-     *
-     * @param  mixed $datetime
-     *
-     * @return DateTimeInterface
+     * @deprecated Use DateTimeFormatter::getDateTimeObject() directly.
      */
     public function getDatetimeObject($datetime = null)
     {
-        if ($datetime instanceof DateTimeInterface) {
-            return $datetime;
-        }
-
-        if (is_integer($datetime)) {
-            $datetime = date('Y-m-d H:i:s', $datetime);
-        }
-
-        return new DateTime($datetime);
+        return $this->formatter->getDatetimeObject($datetime);
     }
 
     public function getName()

--- a/Twig/Extension/TimeExtension.php
+++ b/Twig/Extension/TimeExtension.php
@@ -2,7 +2,7 @@
 
 namespace Knp\Bundle\TimeBundle\Twig\Extension;
 
-use Knp\Bundle\TimeBundle\Templating\Helper\TimeHelper;
+use Knp\Bundle\TimeBundle\DateTimeFormatter;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
 use Twig\TwigFunction;
@@ -22,11 +22,11 @@ use Twig\TwigFunction;
  */
 class TimeExtension extends AbstractExtension
 {
-    protected $helper;
+    protected $formatter;
 
-    public function __construct(TimeHelper $helper)
+    public function __construct(DateTimeFormatter $formatter)
     {
-        $this->helper = $helper;
+        $this->formatter = $formatter;
     }
 
     /**
@@ -38,8 +38,8 @@ class TimeExtension extends AbstractExtension
     {
         return array(
             new TwigFunction(
-                    'time_diff', 
-                    array($this, 'diff'), 
+                    'time_diff',
+                    array($this, 'diff'),
                     array('is_safe' => array('html'))
                 ),
         );
@@ -49,8 +49,8 @@ class TimeExtension extends AbstractExtension
     {
         return array(
             new TwigFilter(
-                    'ago', 
-                    array($this, 'diff'), 
+                    'ago',
+                    array($this, 'diff'),
                     array('is_safe' => array('html'))
                 ),
         );
@@ -58,7 +58,10 @@ class TimeExtension extends AbstractExtension
 
     public function diff($since = null, $to = null)
     {
-        return $this->helper->diff($since, $to);
+        return $this->formatter->formatDiff(
+            $this->formatter->getDatetimeObject($since),
+            $this->formatter->getDatetimeObject($to)
+        );
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
     "require": {
         "php":                          "^7.1.3",
         "symfony/dependency-injection": "~3.4|^4.3|^5.0",
-        "symfony/templating":           "~3.4|^4.3|^5.0",
         "symfony/translation":          "^4.3|^5.0",
         "symfony/config":               "~3.4|^4.3|^5.0"
     },
@@ -28,6 +27,7 @@
     "require-dev": {
         "symfony/framework-bundle": "^4.3|^5.0",
         "symfony/phpunit-bridge": "^4.3|^5.0",
+        "symfony/templating": "~3.4|^4.3|^5.0",
         "symfony/twig-bundle": "^4.3|^5.0"
     },
 


### PR DESCRIPTION
- added DateTimeFormatter::getDatetimeObject()
- deprecated TimeHelper::getDatetimeObject()
- have TimeExtension use DateTimeFormatter directly
- load templating helper only if templating installed
- load twig extension only if twig installed

I was trying to use this bundle as a replacement for the deprecated twig extensions `time_diff` filter. Since `symfony/templating` is deprecated/not recommended I thought it best to remove it as a requirement of this bundle. 

I think there are no BC breaks but let me know if you'd like me to approach this differently.