### PR TITLE
Add compatibility for PHP 8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ matrix:
 
 before_install:
     - phpenv config-rm xdebug.ini || true
-    - composer global require --no-progress --no-scripts --no-plugins symfony/flex dev-master
 
 install:
     - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ matrix:
 
 before_install:
     - phpenv config-rm xdebug.ini || true
+    - composer global require --no-progress --no-scripts --no-plugins symfony/flex dev-main
 
 install:
     - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ env:
 matrix:
     fast_finish: true
     include:
-        - php: 7.1
         - php: 7.2
         - php: 7.3
           env: deps=low

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
 matrix:
     fast_finish: true
     include:
+        - php: 7.1
         - php: 7.2
         - php: 7.3
           env: deps=low

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ public function yourAction(DateTimeFormatter $dateTimeFormatter)
 If you want to run tests, please check that you have installed dev dependencies.
 
 ```bash
-./vendor/bin/phpunit
+./vendor/bin/simple-phpunit
 ```
 
 ## Maintainers

--- a/Tests/DateTimeFormatterTest.php
+++ b/Tests/DateTimeFormatterTest.php
@@ -56,19 +56,17 @@ class DateTimeFormatterTest extends TestCase
         }
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testGetDiffMessageThrowsAnExceptionIfTheDiffIsEmpty()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $this->formatter->getDiffMessage(0, true, 'day');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testGetDiffMessageThrowsAnExceptionIfTheDiffUnitIsNotSupported()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $this->formatter->getDiffMessage(1, true, 'patate');
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
 
     "require": {
-        "php":                          "^7.1.3|^8.0",
+        "php":                          ">=7.1.3",
         "symfony/dependency-injection": "~3.4|^4.3|^5.0",
         "symfony/translation":          "^4.3|^5.0",
         "symfony/config":               "~3.4|^4.3|^5.0"

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
 
     "require": {
-        "php":                          "^7.1.3",
+        "php":                          "^7.1.3|^8.0",
         "symfony/dependency-injection": "~3.4|^4.3|^5.0",
         "symfony/translation":          "^4.3|^5.0",
         "symfony/config":               "~3.4|^4.3|^5.0"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,7 +10,7 @@
          failOnWarning="true"
 >
     <php>
-        <server name="SYMFONY_PHPUNIT_VERSION" value="7.5" />
+        <server name="SYMFONY_PHPUNIT_VERSION" value="8.5" />
     </php>
 
     <testsuites>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,10 +9,6 @@
          failOnRisky="true"
          failOnWarning="true"
 >
-    <php>
-        <server name="SYMFONY_PHPUNIT_VERSION" value="8.5" />
-    </php>
-
     <testsuites>
         <testsuite name="Project Test Suite">
             <directory>Tests</directory>


### PR DESCRIPTION
closes #146 

This PR allows using the bundle with PHP 8.0. 

*Update:*

In order to be compatible I needed to bump the PHPUnit version to `8.5`. This also meant dropping the PHP 7.1 run from Travis as `7.2` is there minimum version. Imo this doesn't hurt as this PHP version is already EOL but there might be other ways using the PHPUnitBridge to work around this if you prefer.

The change in dd3ff7ef4a1c97c2fda0d7007f0f07d9fe30fd65 (dropping global flex plugin in CI run) is unrelated but would otherwise prevent the CI from succeeding. It could also go into another PR if you prefer.