### PR TITLE
[release] v1.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# CHANGELOG
+
+## [v1.16.1](https://github.com/knplabs/KnpTimeBundle/releases/tag/v1.16.1)
+
+*July 13th, 2021*
+
+### Bug Fix
+
+- [#158](https://github.com/knplabs/KnpTimeBundle/pull/158) - Fixed strange construction "za dzień" to "jutro" - *@KerbenII*


### PR DESCRIPTION

Diff: https://github.com/knplabs/KnpTimeBundle/compare/v1.16.0...v1.16.1

## [v1.16.1](https://github.com/knplabs/KnpTimeBundle/releases/tag/v1.16.1)

*July 13th, 2021*

### Bug Fix

- [#158](https://github.com/knplabs/KnpTimeBundle/pull/158) - Fixed strange construction "za dzień" to "jutro" - *@KerbenII*