### PR TITLE
Force DateTime constructor parameter (PHP 8.1 deprecation)

### DIFF
--- a/DateTimeFormatter.php
+++ b/DateTimeFormatter.php
@@ -79,6 +79,10 @@ class DateTimeFormatter
             $dateTime = date('Y-m-d H:i:s', $dateTime);
         }
 
+        if (is_null($dateTime)) {
+            $dateTime = 'now';
+        }
+
         return new DateTime($dateTime);
     }
 


### PR DESCRIPTION
Remove PHP 8.1 deprecation about DateTime constructor by forcing value `now` as string if parameter is null