### PR TITLE
Replaces is_null with null === $var.

### DIFF
--- a/DateTimeFormatter.php
+++ b/DateTimeFormatter.php
@@ -79,7 +79,7 @@ class DateTimeFormatter
             $dateTime = date('Y-m-d H:i:s', $dateTime);
         }
 
-        if (is_null($dateTime)) {
+        if (null === $dateTime) {
             $dateTime = 'now';
         }
 


### PR DESCRIPTION
Risky when the function is_null is overridden.