### PR TITLE
Move `symfony/templating` to dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/dependency-injection": "^5.4|^6.0",
-        "symfony/templating": "^5.4|^6.0",
         "symfony/translation": "^5.4|^6.0",
         "symfony/config": "^5.4|^6.0"
     },
@@ -28,6 +27,7 @@
     "require-dev": {
         "symfony/framework-bundle": "^5.4|^6.0",
         "symfony/phpunit-bridge": "^5.4|^6.0",
+        "symfony/templating": "^5.4|^6.0",
         "symfony/twig-bundle": "^5.4|^6.0"
     },
 


### PR DESCRIPTION
`symfony/templating` is already an optional dependency. There's no reason to force its installation when even `symfony/twig-bundle` isn't required.

https://github.com/KnpLabs/KnpTimeBundle/blob/db453621e84ef0b73905d98ff4bd21a1c8396101/src/DependencyInjection/KnpTimeExtension.php#L23-L25

This component might be deprecated https://github.com/symfony/symfony/pull/51144