### PR TITLE
minor: use long-form duration message for english

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Last edited: {{ post.updatedAt|time_diff }} <!-- Last edited: 1 week ago -->
 
 Event date: {{ event.date|time_diff }} <!-- Event date: in two weeks -->
 
-Read time: {{ post.readTimeInSeconds|duration }} <!-- Read time: 2 mins -->
+Read time: {{ post.readTimeInSeconds|duration }} <!-- Read time: 2 minutes -->
 ```
 
 Want to see it used in a screencast 🎥? Check out SymfonyCasts: https://symfonycasts.com/screencast/symfony-doctrine/ago
@@ -47,7 +47,7 @@ Time formatting:
 Duration formatting:
 
 ```twig
-{{ someDurationInSeconds|duration }} {# 2 mins #}
+{{ someDurationInSeconds|duration }} {# 2 minutes #}
 ```
 
 ### Service
@@ -55,7 +55,7 @@ Duration formatting:
 You can also format dates and durations in your services/controllers by autowiring/injecting the
 `Knp\Bundle\TimeBundle\DateTimeFormatter` service:
 
-```
+```php
 use Knp\Bundle\TimeBundle\DateTimeFormatter;
 // ...
 
@@ -71,7 +71,7 @@ public function yourAction(DateTimeFormatter $dateTimeFormatter)
     return $this->json([
         //  ...
         'published_at' => $agoTime, // 2 years ago
-        'read_time' => $readTime, // 1 min
+        'read_time' => $readTime, // 1 minute
         // ...
     ]);
 }

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -29,14 +29,14 @@ final class IntegrationTest extends TestCase
         $this->assertStringContainsString('Now: now', $result);
 
         $this->assertStringContainsString('1 day ago', $result);
-        $this->assertStringContainsString('Zero: < 1 sec', $result);
-        $this->assertStringContainsString('Less than a second: < 1 sec', $result);
-        $this->assertStringContainsString('One second: 1 sec', $result);
-        $this->assertStringContainsString('Multiple seconds: 59 secs', $result);
-        $this->assertStringContainsString('One minute: 1 min', $result);
-        $this->assertStringContainsString('Multiple minutes: 59 mins', $result);
-        $this->assertStringContainsString('One hour: 1 hr', $result);
-        $this->assertStringContainsString('Multiple hours: 23 hrs', $result);
+        $this->assertStringContainsString('Zero: < 1 second', $result);
+        $this->assertStringContainsString('Less than a second: < 1 second', $result);
+        $this->assertStringContainsString('One second: 1 second', $result);
+        $this->assertStringContainsString('Multiple seconds: 59 seconds', $result);
+        $this->assertStringContainsString('One minute: 1 minute', $result);
+        $this->assertStringContainsString('Multiple minutes: 59 minutes', $result);
+        $this->assertStringContainsString('One hour: 1 hour', $result);
+        $this->assertStringContainsString('Multiple hours: 23 hours', $result);
         $this->assertStringContainsString('One day: 1 day', $result);
         $this->assertStringContainsString('Multiple days: 99 days', $result);
     }

--- a/translations/time.en.xliff
+++ b/translations/time.en.xliff
@@ -56,15 +56,15 @@
             </trans-unit>
             <trans-unit id="14">
                 <source>duration.second</source>
-                <target>1 sec|%count% secs</target>
+                <target>1 second|%count% seconds</target>
             </trans-unit>
             <trans-unit id="15">
                 <source>duration.minute</source>
-                <target>1 min|%count% mins</target>
+                <target>1 minute|%count% minutes</target>
             </trans-unit>
             <trans-unit id="16">
                 <source>duration.hour</source>
-                <target>1 hr|%count% hrs</target>
+                <target>1 hour|%count% hours</target>
             </trans-unit>
             <trans-unit id="17">
                 <source>duration.day</source>
@@ -72,7 +72,7 @@
             </trans-unit>
             <trans-unit id="18">
                 <source>duration.none</source>
-                <target>&lt; 1 sec</target>
+                <target>&lt; 1 second</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
Followup to #177. @weaverryan and I concluded it would be best to _not_ use short forms by default.