### PR TITLE
feat: add age formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Last edited: {{ post.updatedAt|time_diff }} <!-- Last edited: 1 week ago -->
 Event date: {{ event.date|time_diff }} <!-- Event date: in two weeks -->
 
 Read time: {{ post.readTimeInSeconds|duration }} <!-- Read time: 2 minutes -->
+
+Age: {{ user.birthdate|age }} <!-- Age: 30 years old -->
 ```
 
 Want to see it used in a screencast 🎥? Check out SymfonyCasts: https://symfonycasts.com/screencast/symfony-doctrine/ago
@@ -50,6 +52,16 @@ Duration formatting:
 {{ someDurationInSeconds|duration }} {# 2 minutes #}
 ```
 
+Age formatting:
+
+```twig
+{# with filter: #}
+Age: {{ user.birthdate|age }} {# Age: 30 years old #}
+
+{# ... or use the equivalent function: #}
+Age: {{ age(user.birthdate) }} {# Age: 30 years old #}
+```
+
 ### Service
 
 You can also format dates and durations in your services/controllers by autowiring/injecting the
@@ -67,6 +79,8 @@ public function yourAction(DateTimeFormatter $dateTimeFormatter)
     $agoTime = $dateTimeFormatter->formatDiff($someDate, $toDate); // $toDate parameter is optional and defaults to "now"
 
     $readTime = $dateTimeFormatter->formatDuration(64); // or $entity->readTimeInSeconds()
+
+    $ageTime = $dateTimeFormatter->formatAge($someDate, $toDate); // $toDate parameter is optional and defaults to "now"
 
     return $this->json([
         //  ...
@@ -87,6 +101,8 @@ the locale:
 {{ someDateTimeVariable|time_diff(locale='es') }}
 
 {{ someDurationInSeconds|duration(locale='es') }}
+
+{{ someDateTimeVariable|age(locale='es') }}
 ```
 
 ## Tests

--- a/src/DateTimeFormatter.php
+++ b/src/DateTimeFormatter.php
@@ -89,6 +89,22 @@ final class DateTimeFormatter
         return $this->translator->trans('duration.none', [], 'time', $locale);
     }
 
+    /**
+     * Returns a formatted age for the given from and to datetimes.
+     */
+    public function formatAge(
+        int|string|\DateTimeInterface $from,
+        int|string|\DateTimeInterface $to = null,
+        string $locale = null
+    ): string {
+        $from = self::formatDateTime($from);
+        $to = self::formatDateTime($to);
+
+        $diff = $from->diff($to);
+
+        return $this->translator->trans('age', ['%count%' => $diff->y], 'time', $locale);
+    }
+
     private static function formatDateTime(int|string|\DateTimeInterface|null $value): \DateTimeInterface
     {
         if ($value instanceof \DateTimeInterface) {

--- a/src/Twig/Extension/TimeExtension.php
+++ b/src/Twig/Extension/TimeExtension.php
@@ -25,6 +25,11 @@ final class TimeExtension extends AbstractExtension
                 [DateTimeFormatter::class, 'formatDiff'],
                 ['is_safe' => ['html']]
             ),
+            new TwigFunction(
+                'age',
+                [DateTimeFormatter::class, 'formatAge'],
+                ['is_safe' => ['html']]
+            ),
         ];
     }
 
@@ -44,6 +49,11 @@ final class TimeExtension extends AbstractExtension
             new TwigFilter(
                 'duration',
                 [DateTimeFormatter::class, 'formatDuration'],
+                ['is_safe' => ['html']]
+            ),
+            new TwigFilter(
+                'age',
+                [DateTimeFormatter::class, 'formatAge'],
                 ['is_safe' => ['html']]
             ),
         ];

--- a/translations/time.en.xliff
+++ b/translations/time.en.xliff
@@ -74,6 +74,10 @@
                 <source>duration.none</source>
                 <target>&lt; 1 second</target>
             </trans-unit>
+            <trans-unit id="19">
+                <source>age</source>
+                <target>1 year old|%count% years old</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/time.fr.xliff
+++ b/translations/time.fr.xliff
@@ -74,6 +74,10 @@
                 <source>duration.none</source>
                 <target>&lt; 1 seconde</target>
             </trans-unit>
+            <trans-unit id="19">
+                <source>age</source>
+                <target>1 an|%count% ans</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
I add `age` formatter

Examples:
```twig
{# with filter: #}
Age: {{ user.birthdate|age }} <!-- Age: 30 years old -->

{# ... or use the equivalent function: #}
Age: {{ age(user.birthdate) }} <!-- Age: 30 years old -->
```