### PR TITLE
feat: make composer to prefer-stable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,7 @@
     },
 
     "minimum-stability": "dev",
+    "prefer-stable": true,
 
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
Are there any reasons to not prefer the stable versions over devs one?
This would help to make ci more reliable.