### PR TITLE
chore: add tests for PHP 8.4, 8.5

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,8 @@ jobs:
                       symfony: '7.0.*'
                     - php: 8.3
                       symfony: '7.1.*'
+                    - php: 8.4
+                      symfony: '7.1.*'
         steps:
             - uses: zenstruck/.github@php-test-symfony
               with:


### PR DESCRIPTION
Update deprecated github action like suggested

Superseded by https://github.com/KnpLabs/KnpTimeBundle/pull/222