### PR TITLE
feature: add missing duration and age translations

### DIFF
--- a/translations/time.ar.xliff
+++ b/translations/time.ar.xliff
@@ -54,6 +54,30 @@
                 <source>diff.in.year</source>
                 <target>{1}في خلال سنة|{2}في خلال سنتين|[3,10]في خلال %count% سنوات|[11,+Inf]في خلال %count% سنة</target>
             </trans-unit>
+            <trans-unit id="14">
+                <source>duration.second</source>
+                <target>{1}ثانية واحدة|{2}ثانيتان|[3,10]%count% ثوانٍ|[11,+Inf]%count% ثانية</target>
+            </trans-unit>
+            <trans-unit id="15">
+                <source>duration.minute</source>
+                <target>{1}دقيقة واحدة|{2}دقيقتان|[3,10]%count% دقائق|[11,+Inf]%count% دقيقة</target>
+            </trans-unit>
+            <trans-unit id="16">
+                <source>duration.hour</source>
+                <target>{1}ساعة واحدة|{2}ساعتان|[3,10]%count% ساعات|[11,+Inf]%count% ساعة</target>
+            </trans-unit>
+            <trans-unit id="17">
+                <source>duration.day</source>
+                <target>{1}يوم واحد|{2}يومان|[3,10]%count% أيام|[11,+Inf]%count% يوم</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>duration.none</source>
+                <target>أقل من ثانية</target>
+            </trans-unit>
+            <trans-unit id="19">
+                <source>age</source>
+                <target>{1}سنة واحدة|{2}سنتان|[3,10]%count% سنوات|[11,+Inf]%count% سنة</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/time.bg.xliff
+++ b/translations/time.bg.xliff
@@ -54,6 +54,30 @@
                 <source>diff.in.year</source>
                 <target>след 1 година|след %count% години</target>
             </trans-unit>
+            <trans-unit id="14">
+                <source>duration.second</source>
+                <target>1 секунда|%count% секунди</target>
+            </trans-unit>
+            <trans-unit id="15">
+                <source>duration.minute</source>
+                <target>1 минута|%count% минути</target>
+            </trans-unit>
+            <trans-unit id="16">
+                <source>duration.hour</source>
+                <target>1 час|%count% часа</target>
+            </trans-unit>
+            <trans-unit id="17">
+                <source>duration.day</source>
+                <target>1 ден|%count% дни</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>duration.none</source>
+                <target>&lt; 1 секунда</target>
+            </trans-unit>
+            <trans-unit id="19">
+                <source>age</source>
+                <target>1 година|%count% години</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/time.bs_Latn_BA.xliff
+++ b/translations/time.bs_Latn_BA.xliff
@@ -54,6 +54,30 @@
                 <source>diff.in.year</source>
                 <target>u 1 godini|%count% godine</target>
             </trans-unit>
+            <trans-unit id="14">
+                <source>duration.second</source>
+                <target>1 sekunda|%count% sekundi</target>
+            </trans-unit>
+            <trans-unit id="15">
+                <source>duration.minute</source>
+                <target>1 minuta|%count% minuta</target>
+            </trans-unit>
+            <trans-unit id="16">
+                <source>duration.hour</source>
+                <target>1 sat|%count% sati</target>
+            </trans-unit>
+            <trans-unit id="17">
+                <source>duration.day</source>
+                <target>1 dan|%count% dana</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>duration.none</source>
+                <target>&lt; 1 sekunda</target>
+            </trans-unit>
+            <trans-unit id="19">
+                <source>age</source>
+                <target>1 godina|%count% godina</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/time.ca.xliff
+++ b/translations/time.ca.xliff
@@ -54,6 +54,30 @@
                 <source>diff.in.year</source>
                 <target>d'aquí 1 any|d'aquí %count% anys</target>
             </trans-unit>
+            <trans-unit id="14">
+                <source>duration.second</source>
+                <target>1 segon|%count% segons</target>
+            </trans-unit>
+            <trans-unit id="15">
+                <source>duration.minute</source>
+                <target>1 minut|%count% minuts</target>
+            </trans-unit>
+            <trans-unit id="16">
+                <source>duration.hour</source>
+                <target>1 hora|%count% hores</target>
+            </trans-unit>
+            <trans-unit id="17">
+                <source>duration.day</source>
+                <target>1 dia|%count% dies</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>duration.none</source>
+                <target>&lt; 1 segon</target>
+            </trans-unit>
+            <trans-unit id="19">
+                <source>age</source>
+                <target>1 any|%count% anys</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/time.da.xliff
+++ b/translations/time.da.xliff
@@ -54,6 +54,30 @@
                 <source>diff.in.year</source>
                 <target>om %count% år</target>
             </trans-unit>
+            <trans-unit id="14">
+                <source>duration.second</source>
+                <target>1 sekund|%count% sekunder</target>
+            </trans-unit>
+            <trans-unit id="15">
+                <source>duration.minute</source>
+                <target>1 minut|%count% minutter</target>
+            </trans-unit>
+            <trans-unit id="16">
+                <source>duration.hour</source>
+                <target>1 time|%count% timer</target>
+            </trans-unit>
+            <trans-unit id="17">
+                <source>duration.day</source>
+                <target>1 dag|%count% dage</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>duration.none</source>
+                <target>&lt; 1 sekund</target>
+            </trans-unit>
+            <trans-unit id="19">
+                <source>age</source>
+                <target>1 år|%count% år</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/time.eo.xliff
+++ b/translations/time.eo.xliff
@@ -54,6 +54,30 @@
                 <source>diff.in.year</source>
                 <target>post 1 jaro|post %count% jaroj</target>
             </trans-unit>
+            <trans-unit id="14">
+                <source>duration.second</source>
+                <target>1 sekundo|%count% sekundoj</target>
+            </trans-unit>
+            <trans-unit id="15">
+                <source>duration.minute</source>
+                <target>1 minuto|%count% minutoj</target>
+            </trans-unit>
+            <trans-unit id="16">
+                <source>duration.hour</source>
+                <target>1 horo|%count% horoj</target>
+            </trans-unit>
+            <trans-unit id="17">
+                <source>duration.day</source>
+                <target>1 tago|%count% tagoj</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>duration.none</source>
+                <target>&lt; 1 sekundo</target>
+            </trans-unit>
+            <trans-unit id="19">
+                <source>age</source>
+                <target>1 jaro|%count% jaroj</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/time.eu.xliff
+++ b/translations/time.eu.xliff
@@ -54,6 +54,30 @@
                 <source>diff.in.year</source>
                 <target>urtebete barru|%count% urte barru</target>
             </trans-unit>
+            <trans-unit id="14">
+                <source>duration.second</source>
+                <target>segundo bat|%count% segundo</target>
+            </trans-unit>
+            <trans-unit id="15">
+                <source>duration.minute</source>
+                <target>minutu bat|%count% minutu</target>
+            </trans-unit>
+            <trans-unit id="16">
+                <source>duration.hour</source>
+                <target>ordu bat|%count% ordu</target>
+            </trans-unit>
+            <trans-unit id="17">
+                <source>duration.day</source>
+                <target>egun bat|%count% egun</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>duration.none</source>
+                <target>&lt; 1 segundo</target>
+            </trans-unit>
+            <trans-unit id="19">
+                <source>age</source>
+                <target>urte bat|%count% urte</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/time.fi.xliff
+++ b/translations/time.fi.xliff
@@ -54,6 +54,30 @@
                 <source>diff.in.year</source>
                 <target>yhden vuoden päästä|%count% vuoden päästä</target>
             </trans-unit>
+            <trans-unit id="14">
+                <source>duration.second</source>
+                <target>1 sekuntti|%count% sekunttia</target>
+            </trans-unit>
+            <trans-unit id="15">
+                <source>duration.minute</source>
+                <target>1 minuutti|%count% minuuttia</target>
+            </trans-unit>
+            <trans-unit id="16">
+                <source>duration.hour</source>
+                <target>1 tunti|%count% tuntia</target>
+            </trans-unit>
+            <trans-unit id="17">
+                <source>duration.day</source>
+                <target>1 päivä|%count% päivää</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>duration.none</source>
+                <target>&lt; 1 sekuntti</target>
+            </trans-unit>
+            <trans-unit id="19">
+                <source>age</source>
+                <target>1 vuosi|%count% vuotta</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/time.hr_HR.xliff
+++ b/translations/time.hr_HR.xliff
@@ -54,6 +54,30 @@
                 <source>diff.in.year</source>
                 <target>u 1 godini|%count% godine</target>
             </trans-unit>
+            <trans-unit id="14">
+                <source>duration.second</source>
+                <target>1 sekunda|%count% sekundi</target>
+            </trans-unit>
+            <trans-unit id="15">
+                <source>duration.minute</source>
+                <target>1 minuta|%count% minuta</target>
+            </trans-unit>
+            <trans-unit id="16">
+                <source>duration.hour</source>
+                <target>1 sat|%count% sati</target>
+            </trans-unit>
+            <trans-unit id="17">
+                <source>duration.day</source>
+                <target>1 dan|%count% dana</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>duration.none</source>
+                <target>&lt; 1 sekunda</target>
+            </trans-unit>
+            <trans-unit id="19">
+                <source>age</source>
+                <target>1 godina|%count% godina</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/time.hu.xliff
+++ b/translations/time.hu.xliff
@@ -54,6 +54,30 @@
                 <source>diff.in.year</source>
                 <target>1 év múlva|%count% év múlva</target>
             </trans-unit>
+            <trans-unit id="14">
+                <source>duration.second</source>
+                <target>1 másodperc|%count% másodperc</target>
+            </trans-unit>
+            <trans-unit id="15">
+                <source>duration.minute</source>
+                <target>1 perc|%count% perc</target>
+            </trans-unit>
+            <trans-unit id="16">
+                <source>duration.hour</source>
+                <target>1 óra|%count% óra</target>
+            </trans-unit>
+            <trans-unit id="17">
+                <source>duration.day</source>
+                <target>1 nap|%count% nap</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>duration.none</source>
+                <target>&lt; 1 másodperc</target>
+            </trans-unit>
+            <trans-unit id="19">
+                <source>age</source>
+                <target>%count% éves</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/time.id.xliff
+++ b/translations/time.id.xliff
@@ -54,6 +54,30 @@
                 <source>diff.in.year</source>
                 <target>dalam 1 tahun|dalam %count% tahun</target>
             </trans-unit>
+            <trans-unit id="14">
+                <source>duration.second</source>
+                <target>1 detik|%count% detik</target>
+            </trans-unit>
+            <trans-unit id="15">
+                <source>duration.minute</source>
+                <target>1 menit|%count% menit</target>
+            </trans-unit>
+            <trans-unit id="16">
+                <source>duration.hour</source>
+                <target>1 jam|%count% jam</target>
+            </trans-unit>
+            <trans-unit id="17">
+                <source>duration.day</source>
+                <target>1 hari|%count% hari</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>duration.none</source>
+                <target>&lt; 1 detik</target>
+            </trans-unit>
+            <trans-unit id="19">
+                <source>age</source>
+                <target>1 tahun|%count% tahun</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/time.ja.xliff
+++ b/translations/time.ja.xliff
@@ -54,6 +54,30 @@
                 <source>diff.in.year</source>
                 <target>%count%年後</target>
             </trans-unit>
+            <trans-unit id="14">
+                <source>duration.second</source>
+                <target>%count%秒</target>
+            </trans-unit>
+            <trans-unit id="15">
+                <source>duration.minute</source>
+                <target>%count%分</target>
+            </trans-unit>
+            <trans-unit id="16">
+                <source>duration.hour</source>
+                <target>%count%時間</target>
+            </trans-unit>
+            <trans-unit id="17">
+                <source>duration.day</source>
+                <target>%count%日</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>duration.none</source>
+                <target>1秒未満</target>
+            </trans-unit>
+            <trans-unit id="19">
+                <source>age</source>
+                <target>%count%歳</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/time.ky.xliff
+++ b/translations/time.ky.xliff
@@ -54,6 +54,30 @@
                 <source>diff.in.year</source>
                 <target>%count% жылдан кийин</target>
             </trans-unit>
+            <trans-unit id="14">
+                <source>duration.second</source>
+                <target>%count% секунд</target>
+            </trans-unit>
+            <trans-unit id="15">
+                <source>duration.minute</source>
+                <target>%count% минута</target>
+            </trans-unit>
+            <trans-unit id="16">
+                <source>duration.hour</source>
+                <target>%count% саат</target>
+            </trans-unit>
+            <trans-unit id="17">
+                <source>duration.day</source>
+                <target>%count% күн</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>duration.none</source>
+                <target>&lt; 1 секунд</target>
+            </trans-unit>
+            <trans-unit id="19">
+                <source>age</source>
+                <target>%count% жаш</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/time.lt.xliff
+++ b/translations/time.lt.xliff
@@ -54,6 +54,30 @@
                 <source>diff.in.year</source>
                 <target>po metų|po %count% metų|po %count% metų</target>
             </trans-unit>
+            <trans-unit id="14">
+                <source>duration.second</source>
+                <target>1 sekundė|%count% sekundės|%count% sekundžių</target>
+            </trans-unit>
+            <trans-unit id="15">
+                <source>duration.minute</source>
+                <target>1 minutė|%count% minutės|%count% minučių</target>
+            </trans-unit>
+            <trans-unit id="16">
+                <source>duration.hour</source>
+                <target>1 valanda|%count% valandos|%count% valandų</target>
+            </trans-unit>
+            <trans-unit id="17">
+                <source>duration.day</source>
+                <target>1 diena|%count% dienos|%count% dienų</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>duration.none</source>
+                <target>&lt; 1 sekundės</target>
+            </trans-unit>
+            <trans-unit id="19">
+                <source>age</source>
+                <target>1 metai|%count% metai|%count% metų</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/time.nb.xliff
+++ b/translations/time.nb.xliff
@@ -74,6 +74,10 @@
                 <source>duration.none</source> 
                 <target>&lt; 1 sekund</target> 
             </trans-unit>
+            <trans-unit id="19">
+                <source>age</source>
+                <target>1 år|%count% år</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/time.nl.xliff
+++ b/translations/time.nl.xliff
@@ -74,6 +74,10 @@
                 <source>duration.none</source>
                 <target>&lt; 1 seconde</target>
             </trans-unit>
+            <trans-unit id="19">
+                <source>age</source>
+                <target>1 jaar|%count% jaar</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/time.nn.xliff
+++ b/translations/time.nn.xliff
@@ -54,6 +54,30 @@
                 <source>diff.in.year</source>
                 <target>om %count% år</target>
             </trans-unit>
+            <trans-unit id="14">
+                <source>duration.second</source>
+                <target>1 sekund|%count% sekund</target>
+            </trans-unit>
+            <trans-unit id="15">
+                <source>duration.minute</source>
+                <target>1 minutt|%count% minutt</target>
+            </trans-unit>
+            <trans-unit id="16">
+                <source>duration.hour</source>
+                <target>1 time|%count% timar</target>
+            </trans-unit>
+            <trans-unit id="17">
+                <source>duration.day</source>
+                <target>1 dag|%count% dagar</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>duration.none</source>
+                <target>&lt; 1 sekund</target>
+            </trans-unit>
+            <trans-unit id="19">
+                <source>age</source>
+                <target>1 år|%count% år</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/time.pl.xliff
+++ b/translations/time.pl.xliff
@@ -74,6 +74,10 @@
                 <source>duration.none</source>
                 <target>&lt; 1 sekunda</target>
             </trans-unit>
+            <trans-unit id="19">
+                <source>age</source>
+                <target>1 rok|%count% lata|%count% lat</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/time.pt.xliff
+++ b/translations/time.pt.xliff
@@ -54,6 +54,30 @@
                 <source>diff.in.year</source>
                 <target>em 1 ano|em %count% anos</target>
             </trans-unit>
+            <trans-unit id="14">
+                <source>duration.second</source>
+                <target>1 segundo|%count% segundos</target>
+            </trans-unit>
+            <trans-unit id="15">
+                <source>duration.minute</source>
+                <target>1 minuto|%count% minutos</target>
+            </trans-unit>
+            <trans-unit id="16">
+                <source>duration.hour</source>
+                <target>1 hora|%count% horas</target>
+            </trans-unit>
+            <trans-unit id="17">
+                <source>duration.day</source>
+                <target>1 dia|%count% dias</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>duration.none</source>
+                <target>&lt; 1 segundo</target>
+            </trans-unit>
+            <trans-unit id="19">
+                <source>age</source>
+                <target>1 ano|%count% anos</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/time.pt_BR.xliff
+++ b/translations/time.pt_BR.xliff
@@ -54,6 +54,30 @@
                 <source>diff.in.year</source>
                 <target>em 1 ano|em %count% anos</target>
             </trans-unit>
+            <trans-unit id="14">
+                <source>duration.second</source>
+                <target>1 segundo|%count% segundos</target>
+            </trans-unit>
+            <trans-unit id="15">
+                <source>duration.minute</source>
+                <target>1 minuto|%count% minutos</target>
+            </trans-unit>
+            <trans-unit id="16">
+                <source>duration.hour</source>
+                <target>1 hora|%count% horas</target>
+            </trans-unit>
+            <trans-unit id="17">
+                <source>duration.day</source>
+                <target>1 dia|%count% dias</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>duration.none</source>
+                <target>&lt; 1 segundo</target>
+            </trans-unit>
+            <trans-unit id="19">
+                <source>age</source>
+                <target>1 ano|%count% anos</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/time.pt_PT.xliff
+++ b/translations/time.pt_PT.xliff
@@ -54,6 +54,30 @@
                 <source>diff.in.year</source>
                 <target>em 1 ano|em %count% anos</target>
             </trans-unit>
+            <trans-unit id="14">
+                <source>duration.second</source>
+                <target>1 segundo|%count% segundos</target>
+            </trans-unit>
+            <trans-unit id="15">
+                <source>duration.minute</source>
+                <target>1 minuto|%count% minutos</target>
+            </trans-unit>
+            <trans-unit id="16">
+                <source>duration.hour</source>
+                <target>1 hora|%count% horas</target>
+            </trans-unit>
+            <trans-unit id="17">
+                <source>duration.day</source>
+                <target>1 dia|%count% dias</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>duration.none</source>
+                <target>&lt; 1 segundo</target>
+            </trans-unit>
+            <trans-unit id="19">
+                <source>age</source>
+                <target>1 ano|%count% anos</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/time.ro.xliff
+++ b/translations/time.ro.xliff
@@ -54,6 +54,30 @@
                 <source>diff.in.year</source>
                 <target>peste %count% an|peste %count% ani|peste %count% de ani</target>
             </trans-unit>
+            <trans-unit id="14">
+                <source>duration.second</source>
+                <target>%count% secundă|%count% secunde|%count% de secunde</target>
+            </trans-unit>
+            <trans-unit id="15">
+                <source>duration.minute</source>
+                <target>%count% minut|%count% minute|%count% de minute</target>
+            </trans-unit>
+            <trans-unit id="16">
+                <source>duration.hour</source>
+                <target>%count% oră|%count% ore|%count% de ore</target>
+            </trans-unit>
+            <trans-unit id="17">
+                <source>duration.day</source>
+                <target>%count% zi|%count% zile|%count% de zile</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>duration.none</source>
+                <target>&lt; 1 secundă</target>
+            </trans-unit>
+            <trans-unit id="19">
+                <source>age</source>
+                <target>%count% an|%count% ani|%count% de ani</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/time.ru.xliff
+++ b/translations/time.ru.xliff
@@ -74,6 +74,10 @@
                 <source>duration.none</source>
                 <target>&lt; 1 секунды</target>
             </trans-unit>
+            <trans-unit id="19">
+                <source>age</source>
+                <target>%count% год|%count% года|%count% лет</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/time.sk.xliff
+++ b/translations/time.sk.xliff
@@ -74,6 +74,10 @@
                 <source>duration.none</source>
                 <target>&lt; 1 sekunda</target>
             </trans-unit>
+            <trans-unit id="19">
+                <source>age</source>
+                <target>{1}1 rok|[2, 4]%count% roky|[5, Inf]%count% rokov</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/time.sl.xliff
+++ b/translations/time.sl.xliff
@@ -54,6 +54,30 @@
                 <source>diff.in.year</source>
                 <target>{1}za 1 leto|{2}za %count% leti|[3, Inf]za %count% leta</target>
             </trans-unit>
+            <trans-unit id="14">
+                <source>duration.second</source>
+                <target>{1}1 sekunda|{2}%count% sekundi|[3, Inf]%count% sekund</target>
+            </trans-unit>
+            <trans-unit id="15">
+                <source>duration.minute</source>
+                <target>{1}1 minuta|{2}%count% minuti|[3, Inf]%count% minut</target>
+            </trans-unit>
+            <trans-unit id="16">
+                <source>duration.hour</source>
+                <target>{1}1 ura|{2}%count% uri|[3, Inf]%count% ur</target>
+            </trans-unit>
+            <trans-unit id="17">
+                <source>duration.day</source>
+                <target>{1}1 dan|{2}%count% dneva|[3, Inf]%count% dni</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>duration.none</source>
+                <target>&lt; 1 sekunda</target>
+            </trans-unit>
+            <trans-unit id="19">
+                <source>age</source>
+                <target>{1}1 leto|{2}%count% leti|[3, Inf]%count% let</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/time.sr_Latin.xliff
+++ b/translations/time.sr_Latin.xliff
@@ -54,6 +54,30 @@
                 <source>diff.in.year</source>
                 <target>{1}za 1 godinu|[2,Inf]za %count% godine</target>
             </trans-unit>
+            <trans-unit id="14">
+                <source>duration.second</source>
+                <target>{1}1 sekunda|[2,4]%count% sekunde|[5,Inf]%count% sekundi</target>
+            </trans-unit>
+            <trans-unit id="15">
+                <source>duration.minute</source>
+                <target>{1}1 minut|[2,4]%count% minuta|[5,Inf]%count% minuta</target>
+            </trans-unit>
+            <trans-unit id="16">
+                <source>duration.hour</source>
+                <target>{1}1 sat|[2,4]%count% sata|[5,Inf]%count% sati</target>
+            </trans-unit>
+            <trans-unit id="17">
+                <source>duration.day</source>
+                <target>{1}1 dan|[2,Inf]%count% dana</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>duration.none</source>
+                <target>&lt; 1 sekunda</target>
+            </trans-unit>
+            <trans-unit id="19">
+                <source>age</source>
+                <target>{1}1 godina|[2,4]%count% godine|[5,Inf]%count% godina</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/time.sv.xliff
+++ b/translations/time.sv.xliff
@@ -54,6 +54,30 @@
                 <source>diff.in.year</source>
                 <target>om %count% år</target>
             </trans-unit>
+            <trans-unit id="14">
+                <source>duration.second</source>
+                <target>1 sekund|%count% sekunder</target>
+            </trans-unit>
+            <trans-unit id="15">
+                <source>duration.minute</source>
+                <target>1 minut|%count% minuter</target>
+            </trans-unit>
+            <trans-unit id="16">
+                <source>duration.hour</source>
+                <target>1 timme|%count% timmar</target>
+            </trans-unit>
+            <trans-unit id="17">
+                <source>duration.day</source>
+                <target>1 dag|%count% dagar</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>duration.none</source>
+                <target>&lt; 1 sekund</target>
+            </trans-unit>
+            <trans-unit id="19">
+                <source>age</source>
+                <target>1 år|%count% år</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/time.th.xliff
+++ b/translations/time.th.xliff
@@ -54,6 +54,30 @@
                 <source>diff.in.year</source>
                 <target>ใน %count% ปี</target>
             </trans-unit>
+            <trans-unit id="14">
+                <source>duration.second</source>
+                <target>%count% วินาที</target>
+            </trans-unit>
+            <trans-unit id="15">
+                <source>duration.minute</source>
+                <target>%count% นาที</target>
+            </trans-unit>
+            <trans-unit id="16">
+                <source>duration.hour</source>
+                <target>%count% ชั่วโมง</target>
+            </trans-unit>
+            <trans-unit id="17">
+                <source>duration.day</source>
+                <target>%count% วัน</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>duration.none</source>
+                <target>&lt; 1 วินาที</target>
+            </trans-unit>
+            <trans-unit id="19">
+                <source>age</source>
+                <target>%count% ปี</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/time.tr.xliff
+++ b/translations/time.tr.xliff
@@ -54,6 +54,30 @@
                 <source>diff.in.year</source>
                 <target>%count% yıl içinde</target>
             </trans-unit>
+            <trans-unit id="14">
+                <source>duration.second</source>
+                <target>%count% saniye</target>
+            </trans-unit>
+            <trans-unit id="15">
+                <source>duration.minute</source>
+                <target>%count% dakika</target>
+            </trans-unit>
+            <trans-unit id="16">
+                <source>duration.hour</source>
+                <target>%count% saat</target>
+            </trans-unit>
+            <trans-unit id="17">
+                <source>duration.day</source>
+                <target>%count% gün</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>duration.none</source>
+                <target>&lt; 1 saniye</target>
+            </trans-unit>
+            <trans-unit id="19">
+                <source>age</source>
+                <target>%count% yaşında</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/time.uk.xliff
+++ b/translations/time.uk.xliff
@@ -54,6 +54,30 @@
                 <source>diff.in.year</source>
                 <target>через %count% рiк|через %count% роки|через %count% рокiв</target>
             </trans-unit>
+            <trans-unit id="14">
+                <source>duration.second</source>
+                <target>%count% секунда|%count% секунди|%count% секунд</target>
+            </trans-unit>
+            <trans-unit id="15">
+                <source>duration.minute</source>
+                <target>%count% хвилина|%count% хвилини|%count% хвилин</target>
+            </trans-unit>
+            <trans-unit id="16">
+                <source>duration.hour</source>
+                <target>%count% година|%count% години|%count% годин</target>
+            </trans-unit>
+            <trans-unit id="17">
+                <source>duration.day</source>
+                <target>%count% день|%count% днi|%count% днiв</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>duration.none</source>
+                <target>&lt; 1 секунди</target>
+            </trans-unit>
+            <trans-unit id="19">
+                <source>age</source>
+                <target>%count% рiк|%count% роки|%count% рокiв</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/time.vi.xliff
+++ b/translations/time.vi.xliff
@@ -54,6 +54,30 @@
                 <source>diff.in.year</source>
                 <target>trong 1 năm|trong %count% năm</target>
             </trans-unit>
+            <trans-unit id="14">
+                <source>duration.second</source>
+                <target>1 giây|%count% giây</target>
+            </trans-unit>
+            <trans-unit id="15">
+                <source>duration.minute</source>
+                <target>1 phút|%count% phút</target>
+            </trans-unit>
+            <trans-unit id="16">
+                <source>duration.hour</source>
+                <target>1 giờ|%count% giờ</target>
+            </trans-unit>
+            <trans-unit id="17">
+                <source>duration.day</source>
+                <target>1 ngày|%count% ngày</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>duration.none</source>
+                <target>&lt; 1 giây</target>
+            </trans-unit>
+            <trans-unit id="19">
+                <source>age</source>
+                <target>1 tuổi|%count% tuổi</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/time.zh.xliff
+++ b/translations/time.zh.xliff
@@ -54,6 +54,30 @@
                 <source>diff.in.year</source>
                 <target>%count% 年后</target>
             </trans-unit>
+            <trans-unit id="14">
+                <source>duration.second</source>
+                <target>%count% 秒</target>
+            </trans-unit>
+            <trans-unit id="15">
+                <source>duration.minute</source>
+                <target>%count% 分钟</target>
+            </trans-unit>
+            <trans-unit id="16">
+                <source>duration.hour</source>
+                <target>%count% 小时</target>
+            </trans-unit>
+            <trans-unit id="17">
+                <source>duration.day</source>
+                <target>%count% 天</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>duration.none</source>
+                <target>&lt; 1 秒</target>
+            </trans-unit>
+            <trans-unit id="19">
+                <source>age</source>
+                <target>%count% 岁</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/time.zh_CN.xliff
+++ b/translations/time.zh_CN.xliff
@@ -54,6 +54,30 @@
                 <source>diff.in.year</source>
                 <target>%count% 年后</target>
             </trans-unit>
+            <trans-unit id="14">
+                <source>duration.second</source>
+                <target>%count% 秒</target>
+            </trans-unit>
+            <trans-unit id="15">
+                <source>duration.minute</source>
+                <target>%count% 分钟</target>
+            </trans-unit>
+            <trans-unit id="16">
+                <source>duration.hour</source>
+                <target>%count% 小时</target>
+            </trans-unit>
+            <trans-unit id="17">
+                <source>duration.day</source>
+                <target>%count% 天</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>duration.none</source>
+                <target>&lt; 1 秒</target>
+            </trans-unit>
+            <trans-unit id="19">
+                <source>age</source>
+                <target>%count% 岁</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/time.zh_HK.xliff
+++ b/translations/time.zh_HK.xliff
@@ -54,6 +54,30 @@
                 <source>diff.in.year</source>
                 <target>%count% 年後</target>
             </trans-unit>
+            <trans-unit id="14">
+                <source>duration.second</source>
+                <target>%count% 秒</target>
+            </trans-unit>
+            <trans-unit id="15">
+                <source>duration.minute</source>
+                <target>%count% 分鐘</target>
+            </trans-unit>
+            <trans-unit id="16">
+                <source>duration.hour</source>
+                <target>%count% 小時</target>
+            </trans-unit>
+            <trans-unit id="17">
+                <source>duration.day</source>
+                <target>%count% 天</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>duration.none</source>
+                <target>&lt; 1 秒</target>
+            </trans-unit>
+            <trans-unit id="19">
+                <source>age</source>
+                <target>%count% 歲</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/time.zh_TW.xliff
+++ b/translations/time.zh_TW.xliff
@@ -54,6 +54,30 @@
                 <source>diff.in.year</source>
                 <target>%count% 年後</target>
             </trans-unit>
+            <trans-unit id="14">
+                <source>duration.second</source>
+                <target>%count% 秒</target>
+            </trans-unit>
+            <trans-unit id="15">
+                <source>duration.minute</source>
+                <target>%count% 分鐘</target>
+            </trans-unit>
+            <trans-unit id="16">
+                <source>duration.hour</source>
+                <target>%count% 小時</target>
+            </trans-unit>
+            <trans-unit id="17">
+                <source>duration.day</source>
+                <target>%count% 天</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>duration.none</source>
+                <target>&lt; 1 秒</target>
+            </trans-unit>
+            <trans-unit id="19">
+                <source>age</source>
+                <target>%count% 歲</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
Added the following missing translation keys to 35 language files (ar, bg, bs, ca, da, eo, eu, fi, hr, hu, id, ja, ky, lt, nb, nl, nn, pl, pt, pt_BR, pt_PT, ro, ru, sk, sl, sr_Latin, sv, th, tr, uk, vi, zh, zh_CN, zh_HK, zh_TW):

  - `duration.second`
  - `duration.minute`
  - `duration.hour`
  - `duration.day`
  - `duration.none`
  - `age`