### PR TITLE
feat: add zodiac sign calculation as Twig filter/function

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,49 @@ the locale:
 {{ someDateTimeVariable|age(locale='es') }}
 ```
 
+## Zodiac Sign
+
+### Twig
+
+```twig
+{# With filter #}
+{% set zodiac_sign = user.birthdate|zodiac_sign %}
+
+{# ... or use the equivalent function: #}
+{% set zodiac_sign = zodiac_sign(user.birthdate) %}
+
+Your zodiac sign is {{ zodiac_sign.symbol }} {{ zodiac_sign|trans }}
+{# outputs "Your zodiac sign is ♉ Taurus" #}
+
+{# Get translated name with specific locale #}
+{{ zodiac_sign|trans(locale='fr') }}
+{# outputs "Taureau" #}
+```
+
+### Service
+
+You can also format dates in your services/controllers by autowiring/injecting the
+`Knp\Bundle\TimeBundle\DateTimeFormatter` service:
+
+```php
+use Knp\Bundle\TimeBundle\DateTimeFormatter;
+// ...
+
+public function yourAction(DateTimeFormatter $dateTimeFormatter)
+{
+    $someDate = new \DateTimeImmutable('1990-08-01'); // or $entity->getBirthdate()
+
+    $zodiacSign = $dateTimeFormatter->calculateZodiacSign($someDate);
+
+    return $this->json([
+        //  ...
+        'symbol' => $zodiacSign->getSymbol(), // ♌
+        'name'   => $zodiacSign->trans($translator), // Leo
+        // ...
+    ]);
+}
+```
+
 ## Tests
 
 If you want to run tests, please check that you have installed dev dependencies.

--- a/src/DateTimeFormatter.php
+++ b/src/DateTimeFormatter.php
@@ -105,6 +105,29 @@ final class DateTimeFormatter
         return $this->translator->trans('age', ['%count%' => $diff->y], 'time', $locale);
     }
 
+    /**
+     * Returns the zodiac sign for the given date.
+     */
+    public function calculateZodiacSign(\DateTimeInterface|string|int|float|null $date = null): ZodiacSign
+    {
+        $dateTime = match (true) {
+            null === $date => new \DateTimeImmutable(),
+            \is_int($date) => new \DateTimeImmutable('@'.$date),
+            \is_float($date) => new \DateTimeImmutable('@'.(string) (int) $date),
+            \is_string($date) => new \DateTimeImmutable($date),
+            $date instanceof \DateTimeImmutable => $date,
+            default => \DateTimeImmutable::createFromInterface($date),
+        };
+
+        foreach (ZodiacSign::cases() as $zodiacSign) {
+            if ($zodiacSign->contains($dateTime)) {
+                return $zodiacSign;
+            }
+        }
+
+        throw new \InvalidArgumentException(\sprintf('Unable to determine zodiac sign for date "%s".', $dateTime->format(\DateTimeInterface::RFC3339)));
+    }
+
     private static function formatDateTime(int|string|\DateTimeInterface|null $value): \DateTimeInterface
     {
         if ($value instanceof \DateTimeInterface) {

--- a/src/Twig/Extension/TimeExtension.php
+++ b/src/Twig/Extension/TimeExtension.php
@@ -30,6 +30,10 @@ final class TimeExtension extends AbstractExtension
                 [DateTimeFormatter::class, 'formatAge'],
                 ['is_safe' => ['html']]
             ),
+            new TwigFunction(
+                'zodiac_sign',
+                [DateTimeFormatter::class, 'calculateZodiacSign'],
+            ),
         ];
     }
 
@@ -55,6 +59,10 @@ final class TimeExtension extends AbstractExtension
                 'age',
                 [DateTimeFormatter::class, 'formatAge'],
                 ['is_safe' => ['html']]
+            ),
+            new TwigFilter(
+                'zodiac_sign',
+                [DateTimeFormatter::class, 'calculateZodiacSign'],
             ),
         ];
     }

--- a/src/ZodiacSign.php
+++ b/src/ZodiacSign.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Knp\Bundle\TimeBundle;
+
+use Symfony\Contracts\Translation\TranslatableInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+enum ZodiacSign: string implements TranslatableInterface
+{
+    case Aries = 'aries';
+    case Taurus = 'taurus';
+    case Gemini = 'gemini';
+    case Cancer = 'cancer';
+    case Leo = 'leo';
+    case Virgo = 'virgo';
+    case Libra = 'libra';
+    case Scorpio = 'scorpio';
+    case Sagittarius = 'sagittarius';
+    case Capricorn = 'capricorn';
+    case Aquarius = 'aquarius';
+    case Pisces = 'pisces';
+
+    public function trans(TranslatorInterface $translator, ?string $locale = null): string
+    {
+        return $translator->trans('zodiac_sign.'.$this->value, domain: 'zodiac_sign', locale: $locale);
+    }
+
+    public function getSymbol(): string
+    {
+        return match ($this) {
+            self::Aries => '♈',
+            self::Taurus => '♉',
+            self::Gemini => '♊',
+            self::Cancer => '♋',
+            self::Leo => '♌',
+            self::Virgo => '♍',
+            self::Libra => '♎',
+            self::Scorpio => '♏',
+            self::Sagittarius => '♐',
+            self::Capricorn => '♑',
+            self::Aquarius => '♒',
+            self::Pisces => '♓',
+        };
+    }
+
+    public function contains(\DateTimeImmutable $date): bool
+    {
+        $normalized = \DateTimeImmutable::createFromFormat('!m-d', $date->format('m-d'), new \DateTimeZone('UTC'));
+        $start = \DateTimeImmutable::createFromFormat('!m-d', $this->getDateRange()['start'], new \DateTimeZone('UTC'));
+        $end = \DateTimeImmutable::createFromFormat('!m-d', $this->getDateRange()['end'], new \DateTimeZone('UTC'));
+
+        if (self::Capricorn === $this) {
+            return $normalized >= $start || $normalized <= $end;
+        }
+
+        return $normalized >= $start && $normalized <= $end;
+    }
+
+    /** @return array{start: string, end: string} */
+    private function getDateRange(): array
+    {
+        return match ($this) {
+            self::Aquarius => ['start' => '01-20', 'end' => '02-18'],
+            self::Pisces => ['start' => '02-19', 'end' => '03-20'],
+            self::Aries => ['start' => '03-21', 'end' => '04-19'],
+            self::Taurus => ['start' => '04-20', 'end' => '05-20'],
+            self::Gemini => ['start' => '05-21', 'end' => '06-20'],
+            self::Cancer => ['start' => '06-21', 'end' => '07-22'],
+            self::Leo => ['start' => '07-23', 'end' => '08-22'],
+            self::Virgo => ['start' => '08-23', 'end' => '09-22'],
+            self::Libra => ['start' => '09-23', 'end' => '10-22'],
+            self::Scorpio => ['start' => '10-23', 'end' => '11-21'],
+            self::Sagittarius => ['start' => '11-22', 'end' => '12-21'],
+            self::Capricorn => ['start' => '12-22', 'end' => '01-19'],
+        };
+    }
+}

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -61,6 +61,18 @@ final class IntegrationTest extends TestCase
         $this->assertStringContainsString('il y a 1 mois', $result);
     }
 
+    public function testZodiacSignTwigFilter(): void
+    {
+        $result = $this->kernel->getContainer()->get('public.twig')->render('@integration_test/zodiac_sign.twig', [
+            'date' => new \DateTimeImmutable('1990-08-01'),
+        ]);
+
+        $this->assertStringContainsString('Filter value: leo', $result);
+        $this->assertStringContainsString('Filter symbol: ♌', $result);
+        $this->assertStringContainsString('Function value: leo', $result);
+        $this->assertStringContainsString('Function symbol: ♌', $result);
+    }
+
     protected function setUp(): void
     {
         $this->kernel = new TimeBundleIntegrationTestKernel();

--- a/tests/ZodiacSignCalculatorTest.php
+++ b/tests/ZodiacSignCalculatorTest.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace Knp\Bundle\TimeBundle\Tests;
+
+use Knp\Bundle\TimeBundle\DateTimeFormatter;
+use Knp\Bundle\TimeBundle\ZodiacSign;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class ZodiacSignCalculatorTest extends TestCase
+{
+    private DateTimeFormatter $formatter;
+
+    protected function setUp(): void
+    {
+        $translator = $this->getMockBuilder(TranslatorInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->formatter = new DateTimeFormatter($translator);
+    }
+
+    /**
+     * @dataProvider zodiacSignProvider
+     */
+    public function testCalculateZodiacSign(string $date, ZodiacSign $expectedSign): void
+    {
+        $inputs = [
+            'string' => $date,
+            'DateTime' => new \DateTime($date),
+            'DateTimeImmutable' => new \DateTimeImmutable($date),
+        ];
+
+        foreach ($inputs as $type => $input) {
+            $result = $this->formatter->calculateZodiacSign($input);
+            $this->assertSame($expectedSign, $result, \sprintf('Failed for input type: %s', $type));
+        }
+    }
+
+    /**
+     * @dataProvider zodiacSignTimestampProvider
+     */
+    public function testCalculateZodiacSignFromTimestamp(int $timestamp, ZodiacSign $expectedSign): void
+    {
+        $this->assertSame($expectedSign, $this->formatter->calculateZodiacSign($timestamp));
+    }
+
+    public function testCalculateZodiacSignFromFloat(): void
+    {
+        $this->assertSame(ZodiacSign::Aries, $this->formatter->calculateZodiacSign(954028800.5));
+    }
+
+    public function testCalculateZodiacSignWithNullDefaultsToNow(): void
+    {
+        $this->assertContains($this->formatter->calculateZodiacSign(null), ZodiacSign::cases());
+    }
+
+    public function testCalculateZodiacSignWithoutParameterDefaultsToNow(): void
+    {
+        $this->assertContains($this->formatter->calculateZodiacSign(), ZodiacSign::cases());
+    }
+
+    public function testCalculateZodiacSignWithInvalidDateThrows(): void
+    {
+        $this->expectException(\Exception::class);
+        $this->formatter->calculateZodiacSign('not-a-date');
+    }
+
+    public function testBoundaryDates(): void
+    {
+        $this->assertSame(ZodiacSign::Pisces, $this->formatter->calculateZodiacSign('2000-03-20'));
+        $this->assertSame(ZodiacSign::Aries, $this->formatter->calculateZodiacSign('2000-03-21'));
+        $this->assertSame(ZodiacSign::Aries, $this->formatter->calculateZodiacSign('2000-04-19'));
+        $this->assertSame(ZodiacSign::Taurus, $this->formatter->calculateZodiacSign('2000-04-20'));
+    }
+
+    public function testLeapYearDate(): void
+    {
+        $this->assertSame(ZodiacSign::Pisces, $this->formatter->calculateZodiacSign('2000-02-29'));
+    }
+
+    public function testSameSignAcrossDifferentYears(): void
+    {
+        $this->assertSame(ZodiacSign::Leo, $this->formatter->calculateZodiacSign('1990-08-01'));
+        $this->assertSame(ZodiacSign::Leo, $this->formatter->calculateZodiacSign('2000-08-01'));
+        $this->assertSame(ZodiacSign::Leo, $this->formatter->calculateZodiacSign('2050-08-01'));
+    }
+
+    public static function zodiacSignProvider(): array
+    {
+        return [
+            'Aries - start (March 21)' => ['2000-03-21', ZodiacSign::Aries],
+            'Aries - middle (April 1)' => ['2000-04-01', ZodiacSign::Aries],
+            'Aries - end (April 19)' => ['2000-04-19', ZodiacSign::Aries],
+
+            'Taurus - start (April 20)' => ['2000-04-20', ZodiacSign::Taurus],
+            'Taurus - middle (May 1)' => ['2000-05-01', ZodiacSign::Taurus],
+            'Taurus - end (May 20)' => ['2000-05-20', ZodiacSign::Taurus],
+
+            'Gemini - start (May 21)' => ['2000-05-21', ZodiacSign::Gemini],
+            'Gemini - middle (June 1)' => ['2000-06-01', ZodiacSign::Gemini],
+            'Gemini - end (June 20)' => ['2000-06-20', ZodiacSign::Gemini],
+
+            'Cancer - start (June 21)' => ['2000-06-21', ZodiacSign::Cancer],
+            'Cancer - middle (July 1)' => ['2000-07-01', ZodiacSign::Cancer],
+            'Cancer - end (July 22)' => ['2000-07-22', ZodiacSign::Cancer],
+
+            'Leo - start (July 23)' => ['2000-07-23', ZodiacSign::Leo],
+            'Leo - middle (August 1)' => ['2000-08-01', ZodiacSign::Leo],
+            'Leo - end (August 22)' => ['2000-08-22', ZodiacSign::Leo],
+
+            'Virgo - start (August 23)' => ['2000-08-23', ZodiacSign::Virgo],
+            'Virgo - middle (September 1)' => ['2000-09-01', ZodiacSign::Virgo],
+            'Virgo - end (September 22)' => ['2000-09-22', ZodiacSign::Virgo],
+
+            'Libra - start (September 23)' => ['2000-09-23', ZodiacSign::Libra],
+            'Libra - middle (October 1)' => ['2000-10-01', ZodiacSign::Libra],
+            'Libra - end (October 22)' => ['2000-10-22', ZodiacSign::Libra],
+
+            'Scorpio - start (October 23)' => ['2000-10-23', ZodiacSign::Scorpio],
+            'Scorpio - middle (November 1)' => ['2000-11-01', ZodiacSign::Scorpio],
+            'Scorpio - end (November 21)' => ['2000-11-21', ZodiacSign::Scorpio],
+
+            'Sagittarius - start (November 22)' => ['2000-11-22', ZodiacSign::Sagittarius],
+            'Sagittarius - middle (December 1)' => ['2000-12-01', ZodiacSign::Sagittarius],
+            'Sagittarius - end (December 21)' => ['2000-12-21', ZodiacSign::Sagittarius],
+
+            'Capricorn - start (December 22)' => ['2000-12-22', ZodiacSign::Capricorn],
+            'Capricorn - middle (January 1)' => ['2000-01-01', ZodiacSign::Capricorn],
+            'Capricorn - end (January 19)' => ['2000-01-19', ZodiacSign::Capricorn],
+
+            'Aquarius - start (January 20)' => ['2000-01-20', ZodiacSign::Aquarius],
+            'Aquarius - middle (February 1)' => ['2000-02-01', ZodiacSign::Aquarius],
+            'Aquarius - end (February 18)' => ['2000-02-18', ZodiacSign::Aquarius],
+
+            'Pisces - start (February 19)' => ['2000-02-19', ZodiacSign::Pisces],
+            'Pisces - middle (March 1)' => ['2000-03-01', ZodiacSign::Pisces],
+            'Pisces - end (March 20)' => ['2000-03-20', ZodiacSign::Pisces],
+        ];
+    }
+
+    public static function zodiacSignTimestampProvider(): array
+    {
+        return [
+            'Aries (March 25, 2000)' => [954028800, ZodiacSign::Aries],
+            'Taurus (May 1, 2000)' => [957139200, ZodiacSign::Taurus],
+            'Gemini (June 1, 2000)' => [959817600, ZodiacSign::Gemini],
+            'Cancer (July 1, 2000)' => [962409600, ZodiacSign::Cancer],
+            'Leo (August 1, 2000)' => [965088000, ZodiacSign::Leo],
+            'Virgo (September 1, 2000)' => [967766400, ZodiacSign::Virgo],
+            'Libra (October 1, 2000)' => [970358400, ZodiacSign::Libra],
+            'Scorpio (November 1, 2000)' => [973036800, ZodiacSign::Scorpio],
+            'Sagittarius (December 1, 2000)' => [975628800, ZodiacSign::Sagittarius],
+            'Capricorn (January 1, 2000)' => [946684800, ZodiacSign::Capricorn],
+            'Aquarius (February 1, 2000)' => [949363200, ZodiacSign::Aquarius],
+            'Pisces (March 1, 2000)' => [951868800, ZodiacSign::Pisces],
+        ];
+    }
+}

--- a/tests/fixtures/zodiac_sign.twig
+++ b/tests/fixtures/zodiac_sign.twig
@@ -1,0 +1,4 @@
+Filter value: {{ date|zodiac_sign.value }}
+Filter symbol: {{ date|zodiac_sign.symbol }}
+Function value: {{ zodiac_sign(date).value }}
+Function symbol: {{ zodiac_sign(date).symbol }}

--- a/translations/zodiac_sign.ar.xlf
+++ b/translations/zodiac_sign.ar.xlf
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>zodiac_sign.aries</source>
+                <target>الحمل</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>zodiac_sign.taurus</source>
+                <target>الثور</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>zodiac_sign.gemini</source>
+                <target>الجوزاء</target>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>zodiac_sign.cancer</source>
+                <target>السرطان</target>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>zodiac_sign.leo</source>
+                <target>الأسد</target>
+            </trans-unit>
+            <trans-unit id="6">
+                <source>zodiac_sign.virgo</source>
+                <target>العذراء</target>
+            </trans-unit>
+            <trans-unit id="7">
+                <source>zodiac_sign.libra</source>
+                <target>الميزان</target>
+            </trans-unit>
+            <trans-unit id="8">
+                <source>zodiac_sign.scorpio</source>
+                <target>العقرب</target>
+            </trans-unit>
+            <trans-unit id="9">
+                <source>zodiac_sign.sagittarius</source>
+                <target>القوس</target>
+            </trans-unit>
+            <trans-unit id="10">
+                <source>zodiac_sign.capricorn</source>
+                <target>الجدي</target>
+            </trans-unit>
+            <trans-unit id="11">
+                <source>zodiac_sign.aquarius</source>
+                <target>الدلو</target>
+            </trans-unit>
+            <trans-unit id="12">
+                <source>zodiac_sign.pisces</source>
+                <target>الحوت</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/translations/zodiac_sign.bg.xlf
+++ b/translations/zodiac_sign.bg.xlf
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>zodiac_sign.aries</source>
+                <target>Овен</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>zodiac_sign.taurus</source>
+                <target>Телец</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>zodiac_sign.gemini</source>
+                <target>Близнаци</target>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>zodiac_sign.cancer</source>
+                <target>Рак</target>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>zodiac_sign.leo</source>
+                <target>Лъв</target>
+            </trans-unit>
+            <trans-unit id="6">
+                <source>zodiac_sign.virgo</source>
+                <target>Дева</target>
+            </trans-unit>
+            <trans-unit id="7">
+                <source>zodiac_sign.libra</source>
+                <target>Везни</target>
+            </trans-unit>
+            <trans-unit id="8">
+                <source>zodiac_sign.scorpio</source>
+                <target>Скорпион</target>
+            </trans-unit>
+            <trans-unit id="9">
+                <source>zodiac_sign.sagittarius</source>
+                <target>Стрелец</target>
+            </trans-unit>
+            <trans-unit id="10">
+                <source>zodiac_sign.capricorn</source>
+                <target>Козирог</target>
+            </trans-unit>
+            <trans-unit id="11">
+                <source>zodiac_sign.aquarius</source>
+                <target>Водолей</target>
+            </trans-unit>
+            <trans-unit id="12">
+                <source>zodiac_sign.pisces</source>
+                <target>Риби</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/translations/zodiac_sign.bs_Latn_BA.xlf
+++ b/translations/zodiac_sign.bs_Latn_BA.xlf
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>zodiac_sign.aries</source>
+                <target>Ovan</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>zodiac_sign.taurus</source>
+                <target>Bik</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>zodiac_sign.gemini</source>
+                <target>Blizanci</target>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>zodiac_sign.cancer</source>
+                <target>Rak</target>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>zodiac_sign.leo</source>
+                <target>Lav</target>
+            </trans-unit>
+            <trans-unit id="6">
+                <source>zodiac_sign.virgo</source>
+                <target>Djevica</target>
+            </trans-unit>
+            <trans-unit id="7">
+                <source>zodiac_sign.libra</source>
+                <target>Vaga</target>
+            </trans-unit>
+            <trans-unit id="8">
+                <source>zodiac_sign.scorpio</source>
+                <target>Škorpija</target>
+            </trans-unit>
+            <trans-unit id="9">
+                <source>zodiac_sign.sagittarius</source>
+                <target>Strijelac</target>
+            </trans-unit>
+            <trans-unit id="10">
+                <source>zodiac_sign.capricorn</source>
+                <target>Jarac</target>
+            </trans-unit>
+            <trans-unit id="11">
+                <source>zodiac_sign.aquarius</source>
+                <target>Vodolija</target>
+            </trans-unit>
+            <trans-unit id="12">
+                <source>zodiac_sign.pisces</source>
+                <target>Ribe</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/translations/zodiac_sign.ca.xlf
+++ b/translations/zodiac_sign.ca.xlf
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>zodiac_sign.aries</source>
+                <target>Àries</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>zodiac_sign.taurus</source>
+                <target>Taure</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>zodiac_sign.gemini</source>
+                <target>Bessons</target>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>zodiac_sign.cancer</source>
+                <target>Cranc</target>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>zodiac_sign.leo</source>
+                <target>Lleó</target>
+            </trans-unit>
+            <trans-unit id="6">
+                <source>zodiac_sign.virgo</source>
+                <target>Verge</target>
+            </trans-unit>
+            <trans-unit id="7">
+                <source>zodiac_sign.libra</source>
+                <target>Balança</target>
+            </trans-unit>
+            <trans-unit id="8">
+                <source>zodiac_sign.scorpio</source>
+                <target>Escorpí</target>
+            </trans-unit>
+            <trans-unit id="9">
+                <source>zodiac_sign.sagittarius</source>
+                <target>Sagitari</target>
+            </trans-unit>
+            <trans-unit id="10">
+                <source>zodiac_sign.capricorn</source>
+                <target>Capricorn</target>
+            </trans-unit>
+            <trans-unit id="11">
+                <source>zodiac_sign.aquarius</source>
+                <target>Aquari</target>
+            </trans-unit>
+            <trans-unit id="12">
+                <source>zodiac_sign.pisces</source>
+                <target>Peixos</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/translations/zodiac_sign.cs.xlf
+++ b/translations/zodiac_sign.cs.xlf
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>zodiac_sign.aries</source>
+                <target>Beran</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>zodiac_sign.taurus</source>
+                <target>Býk</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>zodiac_sign.gemini</source>
+                <target>Blíženci</target>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>zodiac_sign.cancer</source>
+                <target>Rak</target>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>zodiac_sign.leo</source>
+                <target>Lev</target>
+            </trans-unit>
+            <trans-unit id="6">
+                <source>zodiac_sign.virgo</source>
+                <target>Panna</target>
+            </trans-unit>
+            <trans-unit id="7">
+                <source>zodiac_sign.libra</source>
+                <target>Váhy</target>
+            </trans-unit>
+            <trans-unit id="8">
+                <source>zodiac_sign.scorpio</source>
+                <target>Štír</target>
+            </trans-unit>
+            <trans-unit id="9">
+                <source>zodiac_sign.sagittarius</source>
+                <target>Střelec</target>
+            </trans-unit>
+            <trans-unit id="10">
+                <source>zodiac_sign.capricorn</source>
+                <target>Kozoroh</target>
+            </trans-unit>
+            <trans-unit id="11">
+                <source>zodiac_sign.aquarius</source>
+                <target>Vodnář</target>
+            </trans-unit>
+            <trans-unit id="12">
+                <source>zodiac_sign.pisces</source>
+                <target>Ryby</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/translations/zodiac_sign.da.xlf
+++ b/translations/zodiac_sign.da.xlf
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>zodiac_sign.aries</source>
+                <target>Vædderen</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>zodiac_sign.taurus</source>
+                <target>Tyren</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>zodiac_sign.gemini</source>
+                <target>Tvillingerne</target>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>zodiac_sign.cancer</source>
+                <target>Krebsen</target>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>zodiac_sign.leo</source>
+                <target>Løven</target>
+            </trans-unit>
+            <trans-unit id="6">
+                <source>zodiac_sign.virgo</source>
+                <target>Jomfruen</target>
+            </trans-unit>
+            <trans-unit id="7">
+                <source>zodiac_sign.libra</source>
+                <target>Vægten</target>
+            </trans-unit>
+            <trans-unit id="8">
+                <source>zodiac_sign.scorpio</source>
+                <target>Skorpionen</target>
+            </trans-unit>
+            <trans-unit id="9">
+                <source>zodiac_sign.sagittarius</source>
+                <target>Skytten</target>
+            </trans-unit>
+            <trans-unit id="10">
+                <source>zodiac_sign.capricorn</source>
+                <target>Stenbukken</target>
+            </trans-unit>
+            <trans-unit id="11">
+                <source>zodiac_sign.aquarius</source>
+                <target>Vandmanden</target>
+            </trans-unit>
+            <trans-unit id="12">
+                <source>zodiac_sign.pisces</source>
+                <target>Fiskene</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/translations/zodiac_sign.de.xlf
+++ b/translations/zodiac_sign.de.xlf
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>zodiac_sign.aries</source>
+                <target>Widder</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>zodiac_sign.taurus</source>
+                <target>Stier</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>zodiac_sign.gemini</source>
+                <target>Zwillinge</target>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>zodiac_sign.cancer</source>
+                <target>Krebs</target>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>zodiac_sign.leo</source>
+                <target>Löwe</target>
+            </trans-unit>
+            <trans-unit id="6">
+                <source>zodiac_sign.virgo</source>
+                <target>Jungfrau</target>
+            </trans-unit>
+            <trans-unit id="7">
+                <source>zodiac_sign.libra</source>
+                <target>Waage</target>
+            </trans-unit>
+            <trans-unit id="8">
+                <source>zodiac_sign.scorpio</source>
+                <target>Skorpion</target>
+            </trans-unit>
+            <trans-unit id="9">
+                <source>zodiac_sign.sagittarius</source>
+                <target>Schütze</target>
+            </trans-unit>
+            <trans-unit id="10">
+                <source>zodiac_sign.capricorn</source>
+                <target>Steinbock</target>
+            </trans-unit>
+            <trans-unit id="11">
+                <source>zodiac_sign.aquarius</source>
+                <target>Wassermann</target>
+            </trans-unit>
+            <trans-unit id="12">
+                <source>zodiac_sign.pisces</source>
+                <target>Fische</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/translations/zodiac_sign.en.xlf
+++ b/translations/zodiac_sign.en.xlf
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>zodiac_sign.aries</source>
+                <target>Aries</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>zodiac_sign.taurus</source>
+                <target>Taurus</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>zodiac_sign.gemini</source>
+                <target>Gemini</target>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>zodiac_sign.cancer</source>
+                <target>Cancer</target>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>zodiac_sign.leo</source>
+                <target>Leo</target>
+            </trans-unit>
+            <trans-unit id="6">
+                <source>zodiac_sign.virgo</source>
+                <target>Virgo</target>
+            </trans-unit>
+            <trans-unit id="7">
+                <source>zodiac_sign.libra</source>
+                <target>Libra</target>
+            </trans-unit>
+            <trans-unit id="8">
+                <source>zodiac_sign.scorpio</source>
+                <target>Scorpio</target>
+            </trans-unit>
+            <trans-unit id="9">
+                <source>zodiac_sign.sagittarius</source>
+                <target>Sagittarius</target>
+            </trans-unit>
+            <trans-unit id="10">
+                <source>zodiac_sign.capricorn</source>
+                <target>Capricorn</target>
+            </trans-unit>
+            <trans-unit id="11">
+                <source>zodiac_sign.aquarius</source>
+                <target>Aquarius</target>
+            </trans-unit>
+            <trans-unit id="12">
+                <source>zodiac_sign.pisces</source>
+                <target>Pisces</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/translations/zodiac_sign.eo.xlf
+++ b/translations/zodiac_sign.eo.xlf
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>zodiac_sign.aries</source>
+                <target>Arieso</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>zodiac_sign.taurus</source>
+                <target>Taŭro</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>zodiac_sign.gemini</source>
+                <target>Ĝemeloj</target>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>zodiac_sign.cancer</source>
+                <target>Kankro</target>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>zodiac_sign.leo</source>
+                <target>Leono</target>
+            </trans-unit>
+            <trans-unit id="6">
+                <source>zodiac_sign.virgo</source>
+                <target>Virgulino</target>
+            </trans-unit>
+            <trans-unit id="7">
+                <source>zodiac_sign.libra</source>
+                <target>Pesilo</target>
+            </trans-unit>
+            <trans-unit id="8">
+                <source>zodiac_sign.scorpio</source>
+                <target>Skorpio</target>
+            </trans-unit>
+            <trans-unit id="9">
+                <source>zodiac_sign.sagittarius</source>
+                <target>Sagisto</target>
+            </trans-unit>
+            <trans-unit id="10">
+                <source>zodiac_sign.capricorn</source>
+                <target>Kaprikorno</target>
+            </trans-unit>
+            <trans-unit id="11">
+                <source>zodiac_sign.aquarius</source>
+                <target>Akvoportisto</target>
+            </trans-unit>
+            <trans-unit id="12">
+                <source>zodiac_sign.pisces</source>
+                <target>Fiŝoj</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/translations/zodiac_sign.es.xlf
+++ b/translations/zodiac_sign.es.xlf
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>zodiac_sign.aries</source>
+                <target>Aries</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>zodiac_sign.taurus</source>
+                <target>Tauro</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>zodiac_sign.gemini</source>
+                <target>Géminis</target>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>zodiac_sign.cancer</source>
+                <target>Cáncer</target>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>zodiac_sign.leo</source>
+                <target>Leo</target>
+            </trans-unit>
+            <trans-unit id="6">
+                <source>zodiac_sign.virgo</source>
+                <target>Virgo</target>
+            </trans-unit>
+            <trans-unit id="7">
+                <source>zodiac_sign.libra</source>
+                <target>Libra</target>
+            </trans-unit>
+            <trans-unit id="8">
+                <source>zodiac_sign.scorpio</source>
+                <target>Escorpio</target>
+            </trans-unit>
+            <trans-unit id="9">
+                <source>zodiac_sign.sagittarius</source>
+                <target>Sagitario</target>
+            </trans-unit>
+            <trans-unit id="10">
+                <source>zodiac_sign.capricorn</source>
+                <target>Capricornio</target>
+            </trans-unit>
+            <trans-unit id="11">
+                <source>zodiac_sign.aquarius</source>
+                <target>Acuario</target>
+            </trans-unit>
+            <trans-unit id="12">
+                <source>zodiac_sign.pisces</source>
+                <target>Piscis</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/translations/zodiac_sign.eu.xlf
+++ b/translations/zodiac_sign.eu.xlf
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>zodiac_sign.aries</source>
+                <target>Aretea</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>zodiac_sign.taurus</source>
+                <target>Zezena</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>zodiac_sign.gemini</source>
+                <target>Bikiak</target>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>zodiac_sign.cancer</source>
+                <target>Karramaroa</target>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>zodiac_sign.leo</source>
+                <target>Lehoia</target>
+            </trans-unit>
+            <trans-unit id="6">
+                <source>zodiac_sign.virgo</source>
+                <target>Birjina</target>
+            </trans-unit>
+            <trans-unit id="7">
+                <source>zodiac_sign.libra</source>
+                <target>Balantza</target>
+            </trans-unit>
+            <trans-unit id="8">
+                <source>zodiac_sign.scorpio</source>
+                <target>Eskorpioa</target>
+            </trans-unit>
+            <trans-unit id="9">
+                <source>zodiac_sign.sagittarius</source>
+                <target>Sagitarioa</target>
+            </trans-unit>
+            <trans-unit id="10">
+                <source>zodiac_sign.capricorn</source>
+                <target>Kaprikornioa</target>
+            </trans-unit>
+            <trans-unit id="11">
+                <source>zodiac_sign.aquarius</source>
+                <target>Akuarioa</target>
+            </trans-unit>
+            <trans-unit id="12">
+                <source>zodiac_sign.pisces</source>
+                <target>Arrainak</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/translations/zodiac_sign.fi.xlf
+++ b/translations/zodiac_sign.fi.xlf
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>zodiac_sign.aries</source>
+                <target>Oinas</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>zodiac_sign.taurus</source>
+                <target>Härkä</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>zodiac_sign.gemini</source>
+                <target>Kaksoset</target>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>zodiac_sign.cancer</source>
+                <target>Rapu</target>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>zodiac_sign.leo</source>
+                <target>Leijona</target>
+            </trans-unit>
+            <trans-unit id="6">
+                <source>zodiac_sign.virgo</source>
+                <target>Neitsyt</target>
+            </trans-unit>
+            <trans-unit id="7">
+                <source>zodiac_sign.libra</source>
+                <target>Vaaka</target>
+            </trans-unit>
+            <trans-unit id="8">
+                <source>zodiac_sign.scorpio</source>
+                <target>Skorpioni</target>
+            </trans-unit>
+            <trans-unit id="9">
+                <source>zodiac_sign.sagittarius</source>
+                <target>Jousimies</target>
+            </trans-unit>
+            <trans-unit id="10">
+                <source>zodiac_sign.capricorn</source>
+                <target>Kauris</target>
+            </trans-unit>
+            <trans-unit id="11">
+                <source>zodiac_sign.aquarius</source>
+                <target>Vesimies</target>
+            </trans-unit>
+            <trans-unit id="12">
+                <source>zodiac_sign.pisces</source>
+                <target>Kalat</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/translations/zodiac_sign.fr.xlf
+++ b/translations/zodiac_sign.fr.xlf
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>zodiac_sign.aries</source>
+                <target>Bélier</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>zodiac_sign.taurus</source>
+                <target>Taureau</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>zodiac_sign.gemini</source>
+                <target>Gémeaux</target>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>zodiac_sign.cancer</source>
+                <target>Cancer</target>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>zodiac_sign.leo</source>
+                <target>Lion</target>
+            </trans-unit>
+            <trans-unit id="6">
+                <source>zodiac_sign.virgo</source>
+                <target>Vierge</target>
+            </trans-unit>
+            <trans-unit id="7">
+                <source>zodiac_sign.libra</source>
+                <target>Balance</target>
+            </trans-unit>
+            <trans-unit id="8">
+                <source>zodiac_sign.scorpio</source>
+                <target>Scorpion</target>
+            </trans-unit>
+            <trans-unit id="9">
+                <source>zodiac_sign.sagittarius</source>
+                <target>Sagittaire</target>
+            </trans-unit>
+            <trans-unit id="10">
+                <source>zodiac_sign.capricorn</source>
+                <target>Capricorne</target>
+            </trans-unit>
+            <trans-unit id="11">
+                <source>zodiac_sign.aquarius</source>
+                <target>Verseau</target>
+            </trans-unit>
+            <trans-unit id="12">
+                <source>zodiac_sign.pisces</source>
+                <target>Poissons</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/translations/zodiac_sign.hr_HR.xlf
+++ b/translations/zodiac_sign.hr_HR.xlf
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>zodiac_sign.aries</source>
+                <target>Ovan</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>zodiac_sign.taurus</source>
+                <target>Bik</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>zodiac_sign.gemini</source>
+                <target>Blizanci</target>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>zodiac_sign.cancer</source>
+                <target>Rak</target>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>zodiac_sign.leo</source>
+                <target>Lav</target>
+            </trans-unit>
+            <trans-unit id="6">
+                <source>zodiac_sign.virgo</source>
+                <target>Djevica</target>
+            </trans-unit>
+            <trans-unit id="7">
+                <source>zodiac_sign.libra</source>
+                <target>Vaga</target>
+            </trans-unit>
+            <trans-unit id="8">
+                <source>zodiac_sign.scorpio</source>
+                <target>Škorpion</target>
+            </trans-unit>
+            <trans-unit id="9">
+                <source>zodiac_sign.sagittarius</source>
+                <target>Strijelac</target>
+            </trans-unit>
+            <trans-unit id="10">
+                <source>zodiac_sign.capricorn</source>
+                <target>Jarac</target>
+            </trans-unit>
+            <trans-unit id="11">
+                <source>zodiac_sign.aquarius</source>
+                <target>Vodenjak</target>
+            </trans-unit>
+            <trans-unit id="12">
+                <source>zodiac_sign.pisces</source>
+                <target>Ribe</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/translations/zodiac_sign.hu.xlf
+++ b/translations/zodiac_sign.hu.xlf
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>zodiac_sign.aries</source>
+                <target>Kos</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>zodiac_sign.taurus</source>
+                <target>Bika</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>zodiac_sign.gemini</source>
+                <target>Ikrek</target>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>zodiac_sign.cancer</source>
+                <target>Rák</target>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>zodiac_sign.leo</source>
+                <target>Oroszlán</target>
+            </trans-unit>
+            <trans-unit id="6">
+                <source>zodiac_sign.virgo</source>
+                <target>Szűz</target>
+            </trans-unit>
+            <trans-unit id="7">
+                <source>zodiac_sign.libra</source>
+                <target>Mérleg</target>
+            </trans-unit>
+            <trans-unit id="8">
+                <source>zodiac_sign.scorpio</source>
+                <target>Skorpió</target>
+            </trans-unit>
+            <trans-unit id="9">
+                <source>zodiac_sign.sagittarius</source>
+                <target>Nyilas</target>
+            </trans-unit>
+            <trans-unit id="10">
+                <source>zodiac_sign.capricorn</source>
+                <target>Bak</target>
+            </trans-unit>
+            <trans-unit id="11">
+                <source>zodiac_sign.aquarius</source>
+                <target>Vízöntő</target>
+            </trans-unit>
+            <trans-unit id="12">
+                <source>zodiac_sign.pisces</source>
+                <target>Halak</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/translations/zodiac_sign.id.xlf
+++ b/translations/zodiac_sign.id.xlf
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>zodiac_sign.aries</source>
+                <target>Aries</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>zodiac_sign.taurus</source>
+                <target>Taurus</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>zodiac_sign.gemini</source>
+                <target>Gemini</target>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>zodiac_sign.cancer</source>
+                <target>Cancer</target>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>zodiac_sign.leo</source>
+                <target>Leo</target>
+            </trans-unit>
+            <trans-unit id="6">
+                <source>zodiac_sign.virgo</source>
+                <target>Virgo</target>
+            </trans-unit>
+            <trans-unit id="7">
+                <source>zodiac_sign.libra</source>
+                <target>Libra</target>
+            </trans-unit>
+            <trans-unit id="8">
+                <source>zodiac_sign.scorpio</source>
+                <target>Scorpio</target>
+            </trans-unit>
+            <trans-unit id="9">
+                <source>zodiac_sign.sagittarius</source>
+                <target>Sagitarius</target>
+            </trans-unit>
+            <trans-unit id="10">
+                <source>zodiac_sign.capricorn</source>
+                <target>Capricorn</target>
+            </trans-unit>
+            <trans-unit id="11">
+                <source>zodiac_sign.aquarius</source>
+                <target>Aquarius</target>
+            </trans-unit>
+            <trans-unit id="12">
+                <source>zodiac_sign.pisces</source>
+                <target>Pisces</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/translations/zodiac_sign.it.xlf
+++ b/translations/zodiac_sign.it.xlf
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>zodiac_sign.aries</source>
+                <target>Ariete</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>zodiac_sign.taurus</source>
+                <target>Toro</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>zodiac_sign.gemini</source>
+                <target>Gemelli</target>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>zodiac_sign.cancer</source>
+                <target>Cancro</target>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>zodiac_sign.leo</source>
+                <target>Leone</target>
+            </trans-unit>
+            <trans-unit id="6">
+                <source>zodiac_sign.virgo</source>
+                <target>Vergine</target>
+            </trans-unit>
+            <trans-unit id="7">
+                <source>zodiac_sign.libra</source>
+                <target>Bilancia</target>
+            </trans-unit>
+            <trans-unit id="8">
+                <source>zodiac_sign.scorpio</source>
+                <target>Scorpione</target>
+            </trans-unit>
+            <trans-unit id="9">
+                <source>zodiac_sign.sagittarius</source>
+                <target>Sagittario</target>
+            </trans-unit>
+            <trans-unit id="10">
+                <source>zodiac_sign.capricorn</source>
+                <target>Capricorno</target>
+            </trans-unit>
+            <trans-unit id="11">
+                <source>zodiac_sign.aquarius</source>
+                <target>Acquario</target>
+            </trans-unit>
+            <trans-unit id="12">
+                <source>zodiac_sign.pisces</source>
+                <target>Pesci</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/translations/zodiac_sign.ja.xlf
+++ b/translations/zodiac_sign.ja.xlf
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>zodiac_sign.aries</source>
+                <target>牡羊座</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>zodiac_sign.taurus</source>
+                <target>牡牛座</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>zodiac_sign.gemini</source>
+                <target>双子座</target>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>zodiac_sign.cancer</source>
+                <target>蟹座</target>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>zodiac_sign.leo</source>
+                <target>獅子座</target>
+            </trans-unit>
+            <trans-unit id="6">
+                <source>zodiac_sign.virgo</source>
+                <target>乙女座</target>
+            </trans-unit>
+            <trans-unit id="7">
+                <source>zodiac_sign.libra</source>
+                <target>天秤座</target>
+            </trans-unit>
+            <trans-unit id="8">
+                <source>zodiac_sign.scorpio</source>
+                <target>蠍座</target>
+            </trans-unit>
+            <trans-unit id="9">
+                <source>zodiac_sign.sagittarius</source>
+                <target>射手座</target>
+            </trans-unit>
+            <trans-unit id="10">
+                <source>zodiac_sign.capricorn</source>
+                <target>山羊座</target>
+            </trans-unit>
+            <trans-unit id="11">
+                <source>zodiac_sign.aquarius</source>
+                <target>水瓶座</target>
+            </trans-unit>
+            <trans-unit id="12">
+                <source>zodiac_sign.pisces</source>
+                <target>魚座</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/translations/zodiac_sign.ky.xlf
+++ b/translations/zodiac_sign.ky.xlf
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>zodiac_sign.aries</source>
+                <target>Кочкор</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>zodiac_sign.taurus</source>
+                <target>Бука</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>zodiac_sign.gemini</source>
+                <target>Эгиздер</target>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>zodiac_sign.cancer</source>
+                <target>Рак</target>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>zodiac_sign.leo</source>
+                <target>Арстан</target>
+            </trans-unit>
+            <trans-unit id="6">
+                <source>zodiac_sign.virgo</source>
+                <target>Бойжеткен</target>
+            </trans-unit>
+            <trans-unit id="7">
+                <source>zodiac_sign.libra</source>
+                <target>Таразы</target>
+            </trans-unit>
+            <trans-unit id="8">
+                <source>zodiac_sign.scorpio</source>
+                <target>Чаян</target>
+            </trans-unit>
+            <trans-unit id="9">
+                <source>zodiac_sign.sagittarius</source>
+                <target>Мерген</target>
+            </trans-unit>
+            <trans-unit id="10">
+                <source>zodiac_sign.capricorn</source>
+                <target>Теке</target>
+            </trans-unit>
+            <trans-unit id="11">
+                <source>zodiac_sign.aquarius</source>
+                <target>Суу куюучу</target>
+            </trans-unit>
+            <trans-unit id="12">
+                <source>zodiac_sign.pisces</source>
+                <target>Балык</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/translations/zodiac_sign.lt.xlf
+++ b/translations/zodiac_sign.lt.xlf
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>zodiac_sign.aries</source>
+                <target>Avinas</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>zodiac_sign.taurus</source>
+                <target>Jautis</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>zodiac_sign.gemini</source>
+                <target>Dvyniai</target>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>zodiac_sign.cancer</source>
+                <target>Vėžys</target>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>zodiac_sign.leo</source>
+                <target>Liūtas</target>
+            </trans-unit>
+            <trans-unit id="6">
+                <source>zodiac_sign.virgo</source>
+                <target>Mergelė</target>
+            </trans-unit>
+            <trans-unit id="7">
+                <source>zodiac_sign.libra</source>
+                <target>Svarstyklės</target>
+            </trans-unit>
+            <trans-unit id="8">
+                <source>zodiac_sign.scorpio</source>
+                <target>Skorpionas</target>
+            </trans-unit>
+            <trans-unit id="9">
+                <source>zodiac_sign.sagittarius</source>
+                <target>Šaulys</target>
+            </trans-unit>
+            <trans-unit id="10">
+                <source>zodiac_sign.capricorn</source>
+                <target>Ožiaragis</target>
+            </trans-unit>
+            <trans-unit id="11">
+                <source>zodiac_sign.aquarius</source>
+                <target>Vandenis</target>
+            </trans-unit>
+            <trans-unit id="12">
+                <source>zodiac_sign.pisces</source>
+                <target>Žuvys</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/translations/zodiac_sign.nb.xlf
+++ b/translations/zodiac_sign.nb.xlf
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>zodiac_sign.aries</source>
+                <target>Væren</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>zodiac_sign.taurus</source>
+                <target>Tyren</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>zodiac_sign.gemini</source>
+                <target>Tvillingene</target>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>zodiac_sign.cancer</source>
+                <target>Krepsen</target>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>zodiac_sign.leo</source>
+                <target>Løven</target>
+            </trans-unit>
+            <trans-unit id="6">
+                <source>zodiac_sign.virgo</source>
+                <target>Jomfruen</target>
+            </trans-unit>
+            <trans-unit id="7">
+                <source>zodiac_sign.libra</source>
+                <target>Vekten</target>
+            </trans-unit>
+            <trans-unit id="8">
+                <source>zodiac_sign.scorpio</source>
+                <target>Skorpionen</target>
+            </trans-unit>
+            <trans-unit id="9">
+                <source>zodiac_sign.sagittarius</source>
+                <target>Skytten</target>
+            </trans-unit>
+            <trans-unit id="10">
+                <source>zodiac_sign.capricorn</source>
+                <target>Steinbukken</target>
+            </trans-unit>
+            <trans-unit id="11">
+                <source>zodiac_sign.aquarius</source>
+                <target>Vannmannen</target>
+            </trans-unit>
+            <trans-unit id="12">
+                <source>zodiac_sign.pisces</source>
+                <target>Fiskene</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/translations/zodiac_sign.nl.xlf
+++ b/translations/zodiac_sign.nl.xlf
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>zodiac_sign.aries</source>
+                <target>Ram</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>zodiac_sign.taurus</source>
+                <target>Stier</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>zodiac_sign.gemini</source>
+                <target>Tweelingen</target>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>zodiac_sign.cancer</source>
+                <target>Kreeft</target>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>zodiac_sign.leo</source>
+                <target>Leeuw</target>
+            </trans-unit>
+            <trans-unit id="6">
+                <source>zodiac_sign.virgo</source>
+                <target>Maagd</target>
+            </trans-unit>
+            <trans-unit id="7">
+                <source>zodiac_sign.libra</source>
+                <target>Weegschaal</target>
+            </trans-unit>
+            <trans-unit id="8">
+                <source>zodiac_sign.scorpio</source>
+                <target>Schorpioen</target>
+            </trans-unit>
+            <trans-unit id="9">
+                <source>zodiac_sign.sagittarius</source>
+                <target>Boogschutter</target>
+            </trans-unit>
+            <trans-unit id="10">
+                <source>zodiac_sign.capricorn</source>
+                <target>Steenbok</target>
+            </trans-unit>
+            <trans-unit id="11">
+                <source>zodiac_sign.aquarius</source>
+                <target>Waterman</target>
+            </trans-unit>
+            <trans-unit id="12">
+                <source>zodiac_sign.pisces</source>
+                <target>Vissen</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/translations/zodiac_sign.nn.xlf
+++ b/translations/zodiac_sign.nn.xlf
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>zodiac_sign.aries</source>
+                <target>Vêren</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>zodiac_sign.taurus</source>
+                <target>Tyren</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>zodiac_sign.gemini</source>
+                <target>Tvillingane</target>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>zodiac_sign.cancer</source>
+                <target>Krepsen</target>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>zodiac_sign.leo</source>
+                <target>Løven</target>
+            </trans-unit>
+            <trans-unit id="6">
+                <source>zodiac_sign.virgo</source>
+                <target>Jomfrua</target>
+            </trans-unit>
+            <trans-unit id="7">
+                <source>zodiac_sign.libra</source>
+                <target>Vekta</target>
+            </trans-unit>
+            <trans-unit id="8">
+                <source>zodiac_sign.scorpio</source>
+                <target>Skorpionen</target>
+            </trans-unit>
+            <trans-unit id="9">
+                <source>zodiac_sign.sagittarius</source>
+                <target>Skyttaren</target>
+            </trans-unit>
+            <trans-unit id="10">
+                <source>zodiac_sign.capricorn</source>
+                <target>Steinbukken</target>
+            </trans-unit>
+            <trans-unit id="11">
+                <source>zodiac_sign.aquarius</source>
+                <target>Vassbæraren</target>
+            </trans-unit>
+            <trans-unit id="12">
+                <source>zodiac_sign.pisces</source>
+                <target>Fiskane</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/translations/zodiac_sign.pl.xlf
+++ b/translations/zodiac_sign.pl.xlf
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>zodiac_sign.aries</source>
+                <target>Baran</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>zodiac_sign.taurus</source>
+                <target>Byk</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>zodiac_sign.gemini</source>
+                <target>Bliźnięta</target>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>zodiac_sign.cancer</source>
+                <target>Rak</target>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>zodiac_sign.leo</source>
+                <target>Lew</target>
+            </trans-unit>
+            <trans-unit id="6">
+                <source>zodiac_sign.virgo</source>
+                <target>Panna</target>
+            </trans-unit>
+            <trans-unit id="7">
+                <source>zodiac_sign.libra</source>
+                <target>Waga</target>
+            </trans-unit>
+            <trans-unit id="8">
+                <source>zodiac_sign.scorpio</source>
+                <target>Skorpion</target>
+            </trans-unit>
+            <trans-unit id="9">
+                <source>zodiac_sign.sagittarius</source>
+                <target>Strzelec</target>
+            </trans-unit>
+            <trans-unit id="10">
+                <source>zodiac_sign.capricorn</source>
+                <target>Koziorożec</target>
+            </trans-unit>
+            <trans-unit id="11">
+                <source>zodiac_sign.aquarius</source>
+                <target>Wodnik</target>
+            </trans-unit>
+            <trans-unit id="12">
+                <source>zodiac_sign.pisces</source>
+                <target>Ryby</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/translations/zodiac_sign.pt.xlf
+++ b/translations/zodiac_sign.pt.xlf
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>zodiac_sign.aries</source>
+                <target>Áries</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>zodiac_sign.taurus</source>
+                <target>Touro</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>zodiac_sign.gemini</source>
+                <target>Gêmeos</target>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>zodiac_sign.cancer</source>
+                <target>Câncer</target>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>zodiac_sign.leo</source>
+                <target>Leão</target>
+            </trans-unit>
+            <trans-unit id="6">
+                <source>zodiac_sign.virgo</source>
+                <target>Virgem</target>
+            </trans-unit>
+            <trans-unit id="7">
+                <source>zodiac_sign.libra</source>
+                <target>Libra</target>
+            </trans-unit>
+            <trans-unit id="8">
+                <source>zodiac_sign.scorpio</source>
+                <target>Escorpião</target>
+            </trans-unit>
+            <trans-unit id="9">
+                <source>zodiac_sign.sagittarius</source>
+                <target>Sagitário</target>
+            </trans-unit>
+            <trans-unit id="10">
+                <source>zodiac_sign.capricorn</source>
+                <target>Capricórnio</target>
+            </trans-unit>
+            <trans-unit id="11">
+                <source>zodiac_sign.aquarius</source>
+                <target>Aquário</target>
+            </trans-unit>
+            <trans-unit id="12">
+                <source>zodiac_sign.pisces</source>
+                <target>Peixes</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/translations/zodiac_sign.pt_BR.xlf
+++ b/translations/zodiac_sign.pt_BR.xlf
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>zodiac_sign.aries</source>
+                <target>Áries</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>zodiac_sign.taurus</source>
+                <target>Touro</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>zodiac_sign.gemini</source>
+                <target>Gêmeos</target>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>zodiac_sign.cancer</source>
+                <target>Câncer</target>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>zodiac_sign.leo</source>
+                <target>Leão</target>
+            </trans-unit>
+            <trans-unit id="6">
+                <source>zodiac_sign.virgo</source>
+                <target>Virgem</target>
+            </trans-unit>
+            <trans-unit id="7">
+                <source>zodiac_sign.libra</source>
+                <target>Libra</target>
+            </trans-unit>
+            <trans-unit id="8">
+                <source>zodiac_sign.scorpio</source>
+                <target>Escorpião</target>
+            </trans-unit>
+            <trans-unit id="9">
+                <source>zodiac_sign.sagittarius</source>
+                <target>Sagitário</target>
+            </trans-unit>
+            <trans-unit id="10">
+                <source>zodiac_sign.capricorn</source>
+                <target>Capricórnio</target>
+            </trans-unit>
+            <trans-unit id="11">
+                <source>zodiac_sign.aquarius</source>
+                <target>Aquário</target>
+            </trans-unit>
+            <trans-unit id="12">
+                <source>zodiac_sign.pisces</source>
+                <target>Peixes</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/translations/zodiac_sign.pt_PT.xlf
+++ b/translations/zodiac_sign.pt_PT.xlf
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>zodiac_sign.aries</source>
+                <target>Áries</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>zodiac_sign.taurus</source>
+                <target>Touro</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>zodiac_sign.gemini</source>
+                <target>Gémeos</target>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>zodiac_sign.cancer</source>
+                <target>Caranguejo</target>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>zodiac_sign.leo</source>
+                <target>Leão</target>
+            </trans-unit>
+            <trans-unit id="6">
+                <source>zodiac_sign.virgo</source>
+                <target>Virgem</target>
+            </trans-unit>
+            <trans-unit id="7">
+                <source>zodiac_sign.libra</source>
+                <target>Balança</target>
+            </trans-unit>
+            <trans-unit id="8">
+                <source>zodiac_sign.scorpio</source>
+                <target>Escorpião</target>
+            </trans-unit>
+            <trans-unit id="9">
+                <source>zodiac_sign.sagittarius</source>
+                <target>Sagitário</target>
+            </trans-unit>
+            <trans-unit id="10">
+                <source>zodiac_sign.capricorn</source>
+                <target>Capricórnio</target>
+            </trans-unit>
+            <trans-unit id="11">
+                <source>zodiac_sign.aquarius</source>
+                <target>Aquário</target>
+            </trans-unit>
+            <trans-unit id="12">
+                <source>zodiac_sign.pisces</source>
+                <target>Peixes</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/translations/zodiac_sign.ro.xlf
+++ b/translations/zodiac_sign.ro.xlf
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>zodiac_sign.aries</source>
+                <target>Berbec</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>zodiac_sign.taurus</source>
+                <target>Taur</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>zodiac_sign.gemini</source>
+                <target>Gemeni</target>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>zodiac_sign.cancer</source>
+                <target>Rac</target>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>zodiac_sign.leo</source>
+                <target>Leu</target>
+            </trans-unit>
+            <trans-unit id="6">
+                <source>zodiac_sign.virgo</source>
+                <target>Fecioară</target>
+            </trans-unit>
+            <trans-unit id="7">
+                <source>zodiac_sign.libra</source>
+                <target>Balanță</target>
+            </trans-unit>
+            <trans-unit id="8">
+                <source>zodiac_sign.scorpio</source>
+                <target>Scorpion</target>
+            </trans-unit>
+            <trans-unit id="9">
+                <source>zodiac_sign.sagittarius</source>
+                <target>Săgetător</target>
+            </trans-unit>
+            <trans-unit id="10">
+                <source>zodiac_sign.capricorn</source>
+                <target>Capricorn</target>
+            </trans-unit>
+            <trans-unit id="11">
+                <source>zodiac_sign.aquarius</source>
+                <target>Vărsător</target>
+            </trans-unit>
+            <trans-unit id="12">
+                <source>zodiac_sign.pisces</source>
+                <target>Pești</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/translations/zodiac_sign.ru.xlf
+++ b/translations/zodiac_sign.ru.xlf
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>zodiac_sign.aries</source>
+                <target>Овен</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>zodiac_sign.taurus</source>
+                <target>Телец</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>zodiac_sign.gemini</source>
+                <target>Близнецы</target>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>zodiac_sign.cancer</source>
+                <target>Рак</target>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>zodiac_sign.leo</source>
+                <target>Лев</target>
+            </trans-unit>
+            <trans-unit id="6">
+                <source>zodiac_sign.virgo</source>
+                <target>Дева</target>
+            </trans-unit>
+            <trans-unit id="7">
+                <source>zodiac_sign.libra</source>
+                <target>Весы</target>
+            </trans-unit>
+            <trans-unit id="8">
+                <source>zodiac_sign.scorpio</source>
+                <target>Скорпион</target>
+            </trans-unit>
+            <trans-unit id="9">
+                <source>zodiac_sign.sagittarius</source>
+                <target>Стрелец</target>
+            </trans-unit>
+            <trans-unit id="10">
+                <source>zodiac_sign.capricorn</source>
+                <target>Козерог</target>
+            </trans-unit>
+            <trans-unit id="11">
+                <source>zodiac_sign.aquarius</source>
+                <target>Водолей</target>
+            </trans-unit>
+            <trans-unit id="12">
+                <source>zodiac_sign.pisces</source>
+                <target>Рыбы</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/translations/zodiac_sign.sk.xlf
+++ b/translations/zodiac_sign.sk.xlf
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>zodiac_sign.aries</source>
+                <target>Baran</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>zodiac_sign.taurus</source>
+                <target>Býk</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>zodiac_sign.gemini</source>
+                <target>Blíženci</target>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>zodiac_sign.cancer</source>
+                <target>Rak</target>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>zodiac_sign.leo</source>
+                <target>Lev</target>
+            </trans-unit>
+            <trans-unit id="6">
+                <source>zodiac_sign.virgo</source>
+                <target>Panna</target>
+            </trans-unit>
+            <trans-unit id="7">
+                <source>zodiac_sign.libra</source>
+                <target>Váhy</target>
+            </trans-unit>
+            <trans-unit id="8">
+                <source>zodiac_sign.scorpio</source>
+                <target>Škorpión</target>
+            </trans-unit>
+            <trans-unit id="9">
+                <source>zodiac_sign.sagittarius</source>
+                <target>Strelec</target>
+            </trans-unit>
+            <trans-unit id="10">
+                <source>zodiac_sign.capricorn</source>
+                <target>Kozorožec</target>
+            </trans-unit>
+            <trans-unit id="11">
+                <source>zodiac_sign.aquarius</source>
+                <target>Vodnár</target>
+            </trans-unit>
+            <trans-unit id="12">
+                <source>zodiac_sign.pisces</source>
+                <target>Ryby</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/translations/zodiac_sign.sl.xlf
+++ b/translations/zodiac_sign.sl.xlf
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>zodiac_sign.aries</source>
+                <target>Oven</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>zodiac_sign.taurus</source>
+                <target>Bik</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>zodiac_sign.gemini</source>
+                <target>Dvojčka</target>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>zodiac_sign.cancer</source>
+                <target>Rak</target>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>zodiac_sign.leo</source>
+                <target>Lev</target>
+            </trans-unit>
+            <trans-unit id="6">
+                <source>zodiac_sign.virgo</source>
+                <target>Devica</target>
+            </trans-unit>
+            <trans-unit id="7">
+                <source>zodiac_sign.libra</source>
+                <target>Tehtnica</target>
+            </trans-unit>
+            <trans-unit id="8">
+                <source>zodiac_sign.scorpio</source>
+                <target>Škorpijon</target>
+            </trans-unit>
+            <trans-unit id="9">
+                <source>zodiac_sign.sagittarius</source>
+                <target>Strelec</target>
+            </trans-unit>
+            <trans-unit id="10">
+                <source>zodiac_sign.capricorn</source>
+                <target>Kozorog</target>
+            </trans-unit>
+            <trans-unit id="11">
+                <source>zodiac_sign.aquarius</source>
+                <target>Vodnar</target>
+            </trans-unit>
+            <trans-unit id="12">
+                <source>zodiac_sign.pisces</source>
+                <target>Ribi</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/translations/zodiac_sign.sr_Latin.xlf
+++ b/translations/zodiac_sign.sr_Latin.xlf
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>zodiac_sign.aries</source>
+                <target>Ovan</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>zodiac_sign.taurus</source>
+                <target>Bik</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>zodiac_sign.gemini</source>
+                <target>Blizanci</target>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>zodiac_sign.cancer</source>
+                <target>Rak</target>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>zodiac_sign.leo</source>
+                <target>Lav</target>
+            </trans-unit>
+            <trans-unit id="6">
+                <source>zodiac_sign.virgo</source>
+                <target>Devica</target>
+            </trans-unit>
+            <trans-unit id="7">
+                <source>zodiac_sign.libra</source>
+                <target>Vaga</target>
+            </trans-unit>
+            <trans-unit id="8">
+                <source>zodiac_sign.scorpio</source>
+                <target>Škorpija</target>
+            </trans-unit>
+            <trans-unit id="9">
+                <source>zodiac_sign.sagittarius</source>
+                <target>Strelac</target>
+            </trans-unit>
+            <trans-unit id="10">
+                <source>zodiac_sign.capricorn</source>
+                <target>Jarac</target>
+            </trans-unit>
+            <trans-unit id="11">
+                <source>zodiac_sign.aquarius</source>
+                <target>Vodolija</target>
+            </trans-unit>
+            <trans-unit id="12">
+                <source>zodiac_sign.pisces</source>
+                <target>Ribe</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/translations/zodiac_sign.sv.xlf
+++ b/translations/zodiac_sign.sv.xlf
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>zodiac_sign.aries</source>
+                <target>Väduren</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>zodiac_sign.taurus</source>
+                <target>Oxen</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>zodiac_sign.gemini</source>
+                <target>Tvillingarna</target>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>zodiac_sign.cancer</source>
+                <target>Kräftan</target>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>zodiac_sign.leo</source>
+                <target>Lejonet</target>
+            </trans-unit>
+            <trans-unit id="6">
+                <source>zodiac_sign.virgo</source>
+                <target>Jungfrun</target>
+            </trans-unit>
+            <trans-unit id="7">
+                <source>zodiac_sign.libra</source>
+                <target>Vågen</target>
+            </trans-unit>
+            <trans-unit id="8">
+                <source>zodiac_sign.scorpio</source>
+                <target>Skorpionen</target>
+            </trans-unit>
+            <trans-unit id="9">
+                <source>zodiac_sign.sagittarius</source>
+                <target>Skytten</target>
+            </trans-unit>
+            <trans-unit id="10">
+                <source>zodiac_sign.capricorn</source>
+                <target>Stenbocken</target>
+            </trans-unit>
+            <trans-unit id="11">
+                <source>zodiac_sign.aquarius</source>
+                <target>Vattumannen</target>
+            </trans-unit>
+            <trans-unit id="12">
+                <source>zodiac_sign.pisces</source>
+                <target>Fiskarna</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/translations/zodiac_sign.th.xlf
+++ b/translations/zodiac_sign.th.xlf
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>zodiac_sign.aries</source>
+                <target>ราศีเมษ</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>zodiac_sign.taurus</source>
+                <target>ราศีพฤษภ</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>zodiac_sign.gemini</source>
+                <target>ราศีเมถุน</target>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>zodiac_sign.cancer</source>
+                <target>ราศีกรกฎ</target>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>zodiac_sign.leo</source>
+                <target>ราศีสิงห์</target>
+            </trans-unit>
+            <trans-unit id="6">
+                <source>zodiac_sign.virgo</source>
+                <target>ราศีกันย์</target>
+            </trans-unit>
+            <trans-unit id="7">
+                <source>zodiac_sign.libra</source>
+                <target>ราศีตุลย์</target>
+            </trans-unit>
+            <trans-unit id="8">
+                <source>zodiac_sign.scorpio</source>
+                <target>ราศีพิจิก</target>
+            </trans-unit>
+            <trans-unit id="9">
+                <source>zodiac_sign.sagittarius</source>
+                <target>ราศีธนู</target>
+            </trans-unit>
+            <trans-unit id="10">
+                <source>zodiac_sign.capricorn</source>
+                <target>ราศีมกร</target>
+            </trans-unit>
+            <trans-unit id="11">
+                <source>zodiac_sign.aquarius</source>
+                <target>ราศีกุมภ์</target>
+            </trans-unit>
+            <trans-unit id="12">
+                <source>zodiac_sign.pisces</source>
+                <target>ราศีมีน</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/translations/zodiac_sign.tr.xlf
+++ b/translations/zodiac_sign.tr.xlf
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>zodiac_sign.aries</source>
+                <target>Koç</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>zodiac_sign.taurus</source>
+                <target>Boğa</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>zodiac_sign.gemini</source>
+                <target>İkizler</target>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>zodiac_sign.cancer</source>
+                <target>Yengeç</target>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>zodiac_sign.leo</source>
+                <target>Aslan</target>
+            </trans-unit>
+            <trans-unit id="6">
+                <source>zodiac_sign.virgo</source>
+                <target>Başak</target>
+            </trans-unit>
+            <trans-unit id="7">
+                <source>zodiac_sign.libra</source>
+                <target>Terazi</target>
+            </trans-unit>
+            <trans-unit id="8">
+                <source>zodiac_sign.scorpio</source>
+                <target>Akrep</target>
+            </trans-unit>
+            <trans-unit id="9">
+                <source>zodiac_sign.sagittarius</source>
+                <target>Yay</target>
+            </trans-unit>
+            <trans-unit id="10">
+                <source>zodiac_sign.capricorn</source>
+                <target>Oğlak</target>
+            </trans-unit>
+            <trans-unit id="11">
+                <source>zodiac_sign.aquarius</source>
+                <target>Kova</target>
+            </trans-unit>
+            <trans-unit id="12">
+                <source>zodiac_sign.pisces</source>
+                <target>Balık</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/translations/zodiac_sign.uk.xlf
+++ b/translations/zodiac_sign.uk.xlf
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>zodiac_sign.aries</source>
+                <target>Овен</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>zodiac_sign.taurus</source>
+                <target>Телець</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>zodiac_sign.gemini</source>
+                <target>Близнюки</target>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>zodiac_sign.cancer</source>
+                <target>Рак</target>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>zodiac_sign.leo</source>
+                <target>Лев</target>
+            </trans-unit>
+            <trans-unit id="6">
+                <source>zodiac_sign.virgo</source>
+                <target>Діва</target>
+            </trans-unit>
+            <trans-unit id="7">
+                <source>zodiac_sign.libra</source>
+                <target>Терези</target>
+            </trans-unit>
+            <trans-unit id="8">
+                <source>zodiac_sign.scorpio</source>
+                <target>Скорпіон</target>
+            </trans-unit>
+            <trans-unit id="9">
+                <source>zodiac_sign.sagittarius</source>
+                <target>Стрілець</target>
+            </trans-unit>
+            <trans-unit id="10">
+                <source>zodiac_sign.capricorn</source>
+                <target>Козеріг</target>
+            </trans-unit>
+            <trans-unit id="11">
+                <source>zodiac_sign.aquarius</source>
+                <target>Водолій</target>
+            </trans-unit>
+            <trans-unit id="12">
+                <source>zodiac_sign.pisces</source>
+                <target>Риби</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/translations/zodiac_sign.vi.xlf
+++ b/translations/zodiac_sign.vi.xlf
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>zodiac_sign.aries</source>
+                <target>Bạch Dương</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>zodiac_sign.taurus</source>
+                <target>Kim Ngưu</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>zodiac_sign.gemini</source>
+                <target>Song Tử</target>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>zodiac_sign.cancer</source>
+                <target>Cự Giải</target>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>zodiac_sign.leo</source>
+                <target>Sư Tử</target>
+            </trans-unit>
+            <trans-unit id="6">
+                <source>zodiac_sign.virgo</source>
+                <target>Xử Nữ</target>
+            </trans-unit>
+            <trans-unit id="7">
+                <source>zodiac_sign.libra</source>
+                <target>Thiên Bình</target>
+            </trans-unit>
+            <trans-unit id="8">
+                <source>zodiac_sign.scorpio</source>
+                <target>Thiên Yết</target>
+            </trans-unit>
+            <trans-unit id="9">
+                <source>zodiac_sign.sagittarius</source>
+                <target>Nhân Mã</target>
+            </trans-unit>
+            <trans-unit id="10">
+                <source>zodiac_sign.capricorn</source>
+                <target>Ma Kết</target>
+            </trans-unit>
+            <trans-unit id="11">
+                <source>zodiac_sign.aquarius</source>
+                <target>Bảo Bình</target>
+            </trans-unit>
+            <trans-unit id="12">
+                <source>zodiac_sign.pisces</source>
+                <target>Song Ngư</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/translations/zodiac_sign.zh.xlf
+++ b/translations/zodiac_sign.zh.xlf
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>zodiac_sign.aries</source>
+                <target>白羊座</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>zodiac_sign.taurus</source>
+                <target>金牛座</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>zodiac_sign.gemini</source>
+                <target>双子座</target>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>zodiac_sign.cancer</source>
+                <target>巨蟹座</target>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>zodiac_sign.leo</source>
+                <target>狮子座</target>
+            </trans-unit>
+            <trans-unit id="6">
+                <source>zodiac_sign.virgo</source>
+                <target>处女座</target>
+            </trans-unit>
+            <trans-unit id="7">
+                <source>zodiac_sign.libra</source>
+                <target>天秤座</target>
+            </trans-unit>
+            <trans-unit id="8">
+                <source>zodiac_sign.scorpio</source>
+                <target>天蝎座</target>
+            </trans-unit>
+            <trans-unit id="9">
+                <source>zodiac_sign.sagittarius</source>
+                <target>射手座</target>
+            </trans-unit>
+            <trans-unit id="10">
+                <source>zodiac_sign.capricorn</source>
+                <target>摩羯座</target>
+            </trans-unit>
+            <trans-unit id="11">
+                <source>zodiac_sign.aquarius</source>
+                <target>水瓶座</target>
+            </trans-unit>
+            <trans-unit id="12">
+                <source>zodiac_sign.pisces</source>
+                <target>双鱼座</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/translations/zodiac_sign.zh_CN.xlf
+++ b/translations/zodiac_sign.zh_CN.xlf
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>zodiac_sign.aries</source>
+                <target>白羊座</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>zodiac_sign.taurus</source>
+                <target>金牛座</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>zodiac_sign.gemini</source>
+                <target>双子座</target>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>zodiac_sign.cancer</source>
+                <target>巨蟹座</target>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>zodiac_sign.leo</source>
+                <target>狮子座</target>
+            </trans-unit>
+            <trans-unit id="6">
+                <source>zodiac_sign.virgo</source>
+                <target>处女座</target>
+            </trans-unit>
+            <trans-unit id="7">
+                <source>zodiac_sign.libra</source>
+                <target>天秤座</target>
+            </trans-unit>
+            <trans-unit id="8">
+                <source>zodiac_sign.scorpio</source>
+                <target>天蝎座</target>
+            </trans-unit>
+            <trans-unit id="9">
+                <source>zodiac_sign.sagittarius</source>
+                <target>射手座</target>
+            </trans-unit>
+            <trans-unit id="10">
+                <source>zodiac_sign.capricorn</source>
+                <target>摩羯座</target>
+            </trans-unit>
+            <trans-unit id="11">
+                <source>zodiac_sign.aquarius</source>
+                <target>水瓶座</target>
+            </trans-unit>
+            <trans-unit id="12">
+                <source>zodiac_sign.pisces</source>
+                <target>双鱼座</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/translations/zodiac_sign.zh_HK.xlf
+++ b/translations/zodiac_sign.zh_HK.xlf
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>zodiac_sign.aries</source>
+                <target>白羊座</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>zodiac_sign.taurus</source>
+                <target>金牛座</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>zodiac_sign.gemini</source>
+                <target>雙子座</target>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>zodiac_sign.cancer</source>
+                <target>巨蟹座</target>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>zodiac_sign.leo</source>
+                <target>獅子座</target>
+            </trans-unit>
+            <trans-unit id="6">
+                <source>zodiac_sign.virgo</source>
+                <target>處女座</target>
+            </trans-unit>
+            <trans-unit id="7">
+                <source>zodiac_sign.libra</source>
+                <target>天秤座</target>
+            </trans-unit>
+            <trans-unit id="8">
+                <source>zodiac_sign.scorpio</source>
+                <target>天蠍座</target>
+            </trans-unit>
+            <trans-unit id="9">
+                <source>zodiac_sign.sagittarius</source>
+                <target>射手座</target>
+            </trans-unit>
+            <trans-unit id="10">
+                <source>zodiac_sign.capricorn</source>
+                <target>摩羯座</target>
+            </trans-unit>
+            <trans-unit id="11">
+                <source>zodiac_sign.aquarius</source>
+                <target>水瓶座</target>
+            </trans-unit>
+            <trans-unit id="12">
+                <source>zodiac_sign.pisces</source>
+                <target>雙魚座</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/translations/zodiac_sign.zh_TW.xlf
+++ b/translations/zodiac_sign.zh_TW.xlf
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>zodiac_sign.aries</source>
+                <target>白羊座</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>zodiac_sign.taurus</source>
+                <target>金牛座</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>zodiac_sign.gemini</source>
+                <target>雙子座</target>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>zodiac_sign.cancer</source>
+                <target>巨蟹座</target>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>zodiac_sign.leo</source>
+                <target>獅子座</target>
+            </trans-unit>
+            <trans-unit id="6">
+                <source>zodiac_sign.virgo</source>
+                <target>處女座</target>
+            </trans-unit>
+            <trans-unit id="7">
+                <source>zodiac_sign.libra</source>
+                <target>天秤座</target>
+            </trans-unit>
+            <trans-unit id="8">
+                <source>zodiac_sign.scorpio</source>
+                <target>天蠍座</target>
+            </trans-unit>
+            <trans-unit id="9">
+                <source>zodiac_sign.sagittarius</source>
+                <target>射手座</target>
+            </trans-unit>
+            <trans-unit id="10">
+                <source>zodiac_sign.capricorn</source>
+                <target>摩羯座</target>
+            </trans-unit>
+            <trans-unit id="11">
+                <source>zodiac_sign.aquarius</source>
+                <target>水瓶座</target>
+            </trans-unit>
+            <trans-unit id="12">
+                <source>zodiac_sign.pisces</source>
+                <target>雙魚座</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>


### PR DESCRIPTION
## Summary

  - Adds a `ZodiacSign` PHP enum implementing `TranslatableInterface`, with symbol (♈…♓) and date range logic for all 12 signs
  - Adds `calculateZodiacSign()` on `DateTimeFormatter`, exposable as a Twig filter (`{{ date|zodiac_sign }}`) or function (`{{ zodiac_sign(date) }}`)
  - Ships translation catalogs (`zodiac_sign` domain) for 30+ locales

  ## Usage

  ```twig
  {% set zodiac_sign = user.birthdate|zodiac_sign %}
  {{ zodiac_sign.symbol }} {{ zodiac_sign|trans }}
  ```

  Test plan

  - Unit tests in `ZodiacSignCalculatorTest` covering all 12 signs and edge cases
  - Integration test via zodiac_sign.twig fixture